### PR TITLE
Consolidate API key and improve install instructions styling

### DIFF
--- a/components/LakerunnerHelmValuesWizard.module.css
+++ b/components/LakerunnerHelmValuesWizard.module.css
@@ -429,17 +429,64 @@
 }
 
 .installInstructions {
-  margin-top: 1.5rem;
+  margin-top: 2rem;
+  padding: 1.5rem;
+  background: rgba(33, 150, 243, 0.08);
+  border: 2px solid rgba(33, 150, 243, 0.3);
+  border-radius: 8px;
+}
+
+:global(.dark) .installInstructions {
+  background: rgba(33, 150, 243, 0.1);
+  border-color: rgba(33, 150, 243, 0.4);
+}
+
+.installInstructions > h4:first-child {
+  margin: 0 0 1.25rem 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #1565c0;
+}
+
+:global(.dark) .installInstructions > h4:first-child {
+  color: #64b5f6;
 }
 
 .installInstructions h4 {
-  margin: 0 0 0.75rem 0;
+  margin: 1.5rem 0 0.75rem 0;
   font-size: 1rem;
+  font-weight: 600;
   color: #333;
+}
+
+.installInstructions h4:first-child {
+  margin-top: 0;
 }
 
 :global(.dark) .installInstructions h4 {
   color: #e5e5e5;
+}
+
+.installInstructions p {
+  margin: 0 0 1rem 0;
+  color: #555;
+}
+
+:global(.dark) .installInstructions p {
+  color: #bbb;
+}
+
+.installInstructions a {
+  color: #1976d2;
+  text-decoration: underline;
+}
+
+:global(.dark) .installInstructions a {
+  color: #64b5f6;
+}
+
+.installInstructions pre {
+  margin-bottom: 0;
 }
 
 .privacyNote {

--- a/components/LakerunnerHelmValuesWizard.tsx
+++ b/components/LakerunnerHelmValuesWizard.tsx
@@ -59,10 +59,6 @@ export default function LakerunnerHelmValuesWizard() {
     updateState('apiKey', generateApiKey());
   };
 
-  const handleGenerateGrafanaApiKey = () => {
-    updateState('grafanaApiKey', generateApiKey());
-  };
-
   const handleInstallTypeChange = (installType: InstallType) => {
     setState(prev => ({
       ...prev,
@@ -112,9 +108,9 @@ export default function LakerunnerHelmValuesWizard() {
         </div>
       </section>
 
-      {/* Organization & API Keys */}
+      {/* Organization Settings */}
           <section className={styles.section}>
-            <h3 className={styles.sectionTitle}>Organization & API Keys</h3>
+            <h3 className={styles.sectionTitle}>Organization Settings</h3>
             <div className={styles.formGridTwoCol}>
               <div className={styles.formGroup}>
                 <label>Organization ID <span className={styles.required}>*</span></label>
@@ -135,6 +131,10 @@ export default function LakerunnerHelmValuesWizard() {
                     Must be a valid UUID format
                   </span>
                 )}
+                <span className={styles.hint}>
+                  Lakerunner is multi-tenant. This will be the initial organization ID, and should not change after use.
+                  If you wish to have Cardinal monitor your deployment, sign up on <a href="https://app.cardinalhq.io" target="_blank" rel="noopener noreferrer">app.cardinalhq.io</a> and use the organization ID from that site.
+                </span>
               </div>
               <div className={styles.formGroup}>
                 <label>Collector Name <span className={styles.required}>*</span></label>
@@ -152,13 +152,14 @@ export default function LakerunnerHelmValuesWizard() {
                 )}
               </div>
               <div className={styles.formGroup}>
-                <label>API Key</label>
+                <label>API Key <span className={styles.required}>*</span></label>
                 <div className={styles.inputWithButton}>
                   <input
                     type="text"
                     value={state.apiKey}
                     onChange={(e) => updateState('apiKey', e.target.value)}
                     placeholder="chq_..."
+                    className={!state.apiKey.trim() ? styles.inputError : ''}
                   />
                   <button onClick={handleGenerateApiKey} className={styles.generateBtn}>
                     Generate
@@ -183,26 +184,6 @@ export default function LakerunnerHelmValuesWizard() {
                 <strong>Grafana</strong>
               </label>
               <span className={styles.hint}>Pre-configured Grafana with Lakerunner datasources</span>
-              {state.enableGrafana && (
-                <div className={styles.componentSettings}>
-                  <div className={styles.formGroup}>
-                    <label>Grafana API Key <span className={styles.required}>*</span></label>
-                    <div className={styles.inputWithButton}>
-                      <input
-                        type="text"
-                        value={state.grafanaApiKey}
-                        onChange={(e) => updateState('grafanaApiKey', e.target.value)}
-                        placeholder="chq_..."
-                        className={!state.grafanaApiKey.trim() ? styles.inputError : ''}
-                      />
-                      <button onClick={handleGenerateGrafanaApiKey} className={styles.generateBtn}>
-                        Generate
-                      </button>
-                    </div>
-                    <span className={styles.hint}>Dedicated API key for Grafana to query Lakerunner</span>
-                  </div>
-                </div>
-              )}
             </div>
 
             {/* Collector Component */}

--- a/lib/generateValuesYaml.ts
+++ b/lib/generateValuesYaml.ts
@@ -57,7 +57,6 @@ export interface WizardState {
   organizationId: string;
   collectorName: string;
   apiKey: string;
-  grafanaApiKey: string;
   storage: StorageConfig;
   aws: AWSConfig;
   gcp: GCPConfig;
@@ -89,7 +88,7 @@ export function isValidPort(port: string): boolean {
 export function isBasicsConfigured(state: WizardState): boolean {
   if (!isValidCollectorName(state.collectorName)) return false;
   if (!isValidUUID(state.organizationId)) return false;
-  if (state.enableGrafana && !state.grafanaApiKey.trim()) return false;
+  if (!state.apiKey.trim()) return false;
 
   // Validate storage configuration
   if (!state.storage.bucket.trim()) return false;
@@ -148,7 +147,6 @@ export function createDefaultState(): WizardState {
     organizationId: '',
     collectorName: '',
     apiKey: '',
-    grafanaApiKey: '',
     storage: { bucket: '', region: 'us-east-1', endpoint: '' },
     aws: { credentialMode: 'eks', accessKeyId: '', secretAccessKey: '', existingSecretName: '' },
     gcp: { credentialMode: 'workload_identity', serviceAccountJson: '', existingSecretName: '' },
@@ -186,9 +184,6 @@ export function generateValuesYaml(state: WizardState): string | null {
   lines.push(`    - organization_id: "${state.organizationId}"`);
   lines.push('      keys:');
   lines.push(`        - "${state.apiKey}"`);
-  if (state.enableGrafana && state.grafanaApiKey) {
-    lines.push(`        - "${state.grafanaApiKey}"`);
-  }
   lines.push('');
 
   // Cloud provider credentials
@@ -332,9 +327,9 @@ export function generateValuesYaml(state: WizardState): string | null {
   // Grafana settings
   lines.push('grafana:');
   lines.push(`  enabled: ${state.enableGrafana}`);
-  if (state.enableGrafana && state.grafanaApiKey) {
+  if (state.enableGrafana) {
     lines.push('  cardinal:');
-    lines.push(`    apiKey: "${state.grafanaApiKey}"`);
+    lines.push(`    apiKey: "${state.apiKey}"`);
   }
   lines.push('');
 


### PR DESCRIPTION
## Summary
- Move API key to Organization Settings section and make it required
- Remove separate Grafana API key - Grafana now uses the main API key
- Add help text explaining organization ID multi-tenancy and Cardinal monitoring
- Style installation instructions with distinct blue box for better visibility

## Test plan
- [ ] Verify wizard generates YAML correctly with single API key
- [ ] Confirm Grafana section uses the main API key when enabled
- [ ] Check installation instructions are visually distinct from YAML output
- [ ] Test in both light and dark modes