### PR TITLE
Rename VibeShield to Cardinal Desktop Application

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 This is the Cardinal product documentation site built with [Nextra](https://nextra.site/) (Next.js-based documentation framework) and TypeScript. The site documents two main products:
-- **Cardinal VibeShield** - Platform for building and deploying custom ops agents
+- **Cardinal Desktop Application** - Platform for building and deploying custom ops agents
 - **Lakerunner** - S3-based observability stack
 
 ## Development Commands
@@ -30,7 +30,7 @@ pnpm build
 ### Documentation Structure
 - `pages/` - MDX content files organized by product
   - `pages/_meta.json` - Navigation structure and page titles
-  - `pages/vibeshield/` - VibeShield docs (connectors, product guides, agents)
+  - `pages/vibeshield/` - Desktop Application docs (connectors, product guides, agents)
   - `pages/lakerunner/` - Lakerunner docs
 - `components/` - React components used in MDX pages
 - `theme.config.tsx` - Nextra theme configuration (logo, SEO, footer)

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -1,5 +1,5 @@
 {
   "index": "Welcome",
-  "vibeshield": "Cardinal VibeShield",
+  "vibeshield": "Cardinal Desktop Application",
   "lakerunner": "Lakerunner"
 }

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -7,7 +7,7 @@ Hello, and welcome! 👋
  New to Cardinal? We've got you covered, with a simple Quick Start to get you going:
 
 ## Our Products
-- [Cardinal VibeShield](/vibeshield/get_started) Build and deploy custom ops agents to monitor your infrastructure.
+- [Cardinal Desktop Application](/vibeshield/get_started) Build and deploy custom ops agents to monitor your infrastructure.
 - [Lakerunner](/lakerunner) - Turn an S3 bucket into a production-grade Observability stack in minutes.
 
 Existing Cardinal customers can find more detailed documentation in the sidebar.

--- a/pages/vibeshield/agents/datadog-release-agent.mdx
+++ b/pages/vibeshield/agents/datadog-release-agent.mdx
@@ -17,11 +17,11 @@ Invoke the release check workflow via a simple HTTP webhook as part of your GitH
 
 ### 1. Set Up Workspace
 
-If this is your first time using Cardinal VibeShield, follow the [Get Started](/vibeshield/get_started) guide to sign up for a free Cardinal account, and set up your team's workspace.
+If this is your first time using Cardinal Desktop Application, follow the [Get Started](/vibeshield/get_started) guide to sign up for a free Cardinal account, and set up your team's workspace.
 
 ### 2. Add Datadog Connector
 
-1. In the VibeShield app, select the **Connectors** tab from the sidebar.
+1. In the Cardinal Desktop Application, select the **Connectors** tab from the sidebar.
 
 2. In the **Browse Connectors** tab, click the **Connect** button on the Datadog connector.
 
@@ -31,7 +31,7 @@ Refer to the [Datadog Connector guide](/vibeshield/connectors/datadog) for detai
 
 ### 3. Add Slack Connector
 
-1. In the VibeShield app, select the **Connectors** tab from the sidebar.
+1. In the Cardinal Desktop Application, select the **Connectors** tab from the sidebar.
 
 2. In the **Browse Connectors** tab, click the **Connect** button on the Slack connector.
 
@@ -41,7 +41,7 @@ Refer to the [Slack Connector guide](/vibeshield/connectors/slack) for detailed 
 
 ### 4. Import the Datadog Release Agent
 
-1. In the VibeShield app, select the **Agents** tab from the sidebar.
+1. In the Cardinal Desktop Application, select the **Agents** tab from the sidebar.
 
 2. From the **Agent Templates** section, select the **datadog-release-agent** template, and give it a name to import it into your workspace.
 

--- a/pages/vibeshield/connectors/athena.mdx
+++ b/pages/vibeshield/connectors/athena.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="AWS Athena" />
 
 
-Connect Cardinal VibeShield to Amazon Athena for serverless SQL queries on S3 data.
+Connect Cardinal Desktop Application to Amazon Athena for serverless SQL queries on S3 data.
 
 ## Overview
 
@@ -65,7 +65,7 @@ Amazon Athena is a serverless query service that allows you to analyze data stor
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **AWS Athena**
 3. Enter a **Display Name** for this connection (e.g., "Athena Prod", "Athena Analytics")
 4. Select your **AWS Region** where Athena is running
@@ -189,7 +189,7 @@ Amazon Athena is a serverless query service that allows you to analyze data stor
    - Selected database
    - Selected tables
 2. Click **Save**
-3. Cardinal VibeShield will verify connectivity and access to your Athena data
+3. Cardinal Desktop Application will verify connectivity and access to your Athena data
 
 
 </div>

--- a/pages/vibeshield/connectors/bigquery-insights.mdx
+++ b/pages/vibeshield/connectors/bigquery-insights.mdx
@@ -3,7 +3,7 @@ import SupportCallout from '../../../components/SupportCallout';
 
 <ConnectorTitle name="Google BigQuery Insights" />
 
-Connect Cardinal VibeShield to Google BigQuery Insights for query performance monitoring.
+Connect Cardinal Desktop Application to Google BigQuery Insights for query performance monitoring.
 
 ## Overview
 
@@ -61,7 +61,7 @@ Validate credentials either through ADC or Oauth.
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Google BigQuery Insights**
 3. Enter a **Display Name** for this datasource connection (e.g., "BigQuery Insights Prod", "BigQuery Insights Dev")
 
@@ -134,7 +134,7 @@ Validate credentials either through ADC or Oauth.
 
 1. Review your selected project and display name
 2. Click **Save**
-3. Cardinal VibeShield will verify connectivity and access to Query Insights
+3. Cardinal Desktop Application will verify connectivity and access to Query Insights
 
 <img
   src="/bigquery-insights-step.png"

--- a/pages/vibeshield/connectors/bigquery.mdx
+++ b/pages/vibeshield/connectors/bigquery.mdx
@@ -3,7 +3,7 @@ import SupportCallout from '../../../components/SupportCallout';
 
 <ConnectorTitle name="BigQuery" />
 
-Connect Cardinal VibeShield to Google BigQuery data warehouse.
+Connect Cardinal Desktop Application to Google BigQuery data warehouse.
 
 ## Overview
 
@@ -65,12 +65,12 @@ Validate credentials either through ADC or Oauth.
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **BigQuery**
 3. Click **Authenticate with Google**
 4. You'll be redirected to Google's OAuth consent screen
-5. Grant Cardinal VibeShield access to your BigQuery data
-6. Return to Cardinal VibeShield — authentication is complete
+5. Grant Cardinal Desktop Application access to your BigQuery data
+6. Return to Cardinal Desktop Application — authentication is complete
 
 <img
   src="/bigquery-step-1.png"
@@ -200,7 +200,7 @@ Validate credentials either through ADC or Oauth.
 
 1. Review your selected project, datasets, and tables
 2. Click **Save**
-3. Cardinal VibeShield will verify connectivity and discover the schema for your selected datasets and tables
+3. Cardinal Desktop Application will verify connectivity and discover the schema for your selected datasets and tables
 
 <img
   src="/bigquery-step-4.png"

--- a/pages/vibeshield/connectors/clickhouse.mdx
+++ b/pages/vibeshield/connectors/clickhouse.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="ClickHouse" />
 
 
-Connect Cardinal VibeShield to ClickHouse for querying and analyzing data in your ClickHouse cluster.
+Connect Cardinal Desktop Application to ClickHouse for querying and analyzing data in your ClickHouse cluster.
 
 ## Overview
 
@@ -65,7 +65,7 @@ ClickHouse is a fast, open-source columnar database management system. With the 
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **ClickHouse**
 3. Enter your **Server Address**
    - Format: `host:port` (e.g., `localhost:9000` for native, `localhost:8123` for HTTP)
@@ -259,7 +259,7 @@ ClickHouse is a fast, open-source columnar database management system. With the 
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your ClickHouse server
+2. Cardinal Desktop Application will verify connectivity to your ClickHouse server
 
 
 </div>

--- a/pages/vibeshield/connectors/cloudwatch.mdx
+++ b/pages/vibeshield/connectors/cloudwatch.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="AWS CloudWatch" />
 
 
-Connect Cardinal VibeShield to Amazon CloudWatch for monitoring logs and metrics.
+Connect Cardinal Desktop Application to Amazon CloudWatch for monitoring logs and metrics.
 
 ## Overview
 
@@ -63,7 +63,7 @@ Amazon CloudWatch is a monitoring and observability service for AWS resources an
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **AWS CloudWatch**
 3. Enter a **Display Name** for this connection (e.g., "CloudWatch Prod", "CloudWatch Dev")
 4. Select your **AWS Region** where CloudWatch is running

--- a/pages/vibeshield/connectors/datadog.mdx
+++ b/pages/vibeshield/connectors/datadog.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Datadog" />
 
 
-Connect Cardinal VibeShield to Datadog for monitoring logs, metrics, and traces.
+Connect Cardinal Desktop Application to Datadog for monitoring logs, metrics, and traces.
 
 ## Overview
 
@@ -57,7 +57,7 @@ To find or create keys:
 1. Navigate to the appropriate URL for your site
 2. Find an existing key or click **Create API Key** / **Create Application Key**
 3. API keys start with `dd_`
-4. Copy the key and paste it into Cardinal VibeShield
+4. Copy the key and paste it into Cardinal Desktop Application
 
 ### Datadog Site
 
@@ -103,7 +103,7 @@ Check your Datadog URL to confirm your site.
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Datadog**
 3. Enter a **Display Name** for this datasource connection (e.g., "Datadog Prod", "Datadog Dev")
 
@@ -230,7 +230,7 @@ Check your Datadog URL to confirm your site.
 
 1. Review the configuration
 2. Click **Save**
-3. Cardinal VibeShield will verify the connection
+3. Cardinal Desktop Application will verify the connection
 
 
 </div>

--- a/pages/vibeshield/connectors/elasticsearch.mdx
+++ b/pages/vibeshield/connectors/elasticsearch.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Elasticsearch" />
 
 
-Connect Cardinal VibeShield to Elasticsearch for querying and analyzing logs, metrics, and search data.
+Connect Cardinal Desktop Application to Elasticsearch for querying and analyzing logs, metrics, and search data.
 
 ## Overview
 
@@ -63,7 +63,7 @@ Elasticsearch is a distributed search and analytics engine. With the Elasticsear
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Elasticsearch**
 3. Enter a **Display Name** for this Elasticsearch connection
    - Example: `Elasticsearch`, `Prod Logs`, `Analytics Cluster`
@@ -192,7 +192,7 @@ Elasticsearch is a distributed search and analytics engine. With the Elasticsear
 
 1. Click **Next** to verify and continue
 2. Click **Save** to complete the configuration
-3. Cardinal VibeShield will verify connectivity to your Elasticsearch cluster
+3. Cardinal Desktop Application will verify connectivity to your Elasticsearch cluster
 
 
 </div>

--- a/pages/vibeshield/connectors/gcp-monitoring.mdx
+++ b/pages/vibeshield/connectors/gcp-monitoring.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Google Cloud Monitoring" />
 
 
-Connect Cardinal VibeShield to Google Cloud Platform's Cloud Monitoring and Cloud Logging.
+Connect Cardinal Desktop Application to Google Cloud Platform's Cloud Monitoring and Cloud Logging.
 
 ## Overview
 
@@ -95,12 +95,12 @@ Or in Google Cloud Console:
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Google Cloud Monitoring**
 3. Click **Authenticate with Google**
 4. You'll be redirected to Google's OAuth consent screen
-5. Grant Cardinal VibeShield access to your GCP resources
-6. Return to Cardinal VibeShield — authentication is complete
+5. Grant Cardinal Desktop Application access to your GCP resources
+6. Return to Cardinal Desktop Application — authentication is complete
 
 
 </div>
@@ -173,7 +173,7 @@ Or in Google Cloud Console:
 
 1. Review your selected project
 2. Click **Save**
-3. Cardinal VibeShield will verify connectivity
+3. Cardinal Desktop Application will verify connectivity
 
 
 </div>

--- a/pages/vibeshield/connectors/github.mdx
+++ b/pages/vibeshield/connectors/github.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="GitHub" />
 
 
-Connect Cardinal VibeShield to GitHub for accessing repositories, issues, and pull requests.
+Connect Cardinal Desktop Application to GitHub for accessing repositories, issues, and pull requests.
 
 ## Overview
 
@@ -43,7 +43,7 @@ GitHub is a platform for version control and collaborative development. With the
    - **read:org** - Read organization data
    - **read:user** - Read user profile data
 5. Click "Generate token"
-6. Copy the token and paste it into Cardinal VibeShield (tokens start with `ghp_`)
+6. Copy the token and paste it into Cardinal Desktop Application (tokens start with `ghp_`)
 
 ## Setup Wizard
 
@@ -75,7 +75,7 @@ GitHub is a platform for version control and collaborative development. With the
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **GitHub**
 3. Enter a **Display Name** for this connection
    - Example: "GitHub Prod", "GitHub Dev", "My GitHub"
@@ -192,7 +192,7 @@ GitHub is a platform for version control and collaborative development. With the
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your GitHub MCP server
+2. Cardinal Desktop Application will verify connectivity to your GitHub MCP server
 
 
 </div>

--- a/pages/vibeshield/connectors/grafana.mdx
+++ b/pages/vibeshield/connectors/grafana.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Grafana" />
 
 
-Connect Cardinal VibeShield to Grafana for querying and analyzing logs, traces, and metrics from Loki, Tempo, and Mimir.
+Connect Cardinal Desktop Application to Grafana for querying and analyzing logs, traces, and metrics from Loki, Tempo, and Mimir.
 
 ## Overview
 
@@ -62,7 +62,7 @@ Grafana is an open-source visualization and monitoring platform. With the Grafan
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Grafana**
 3. Enter a **Display Name** for this Grafana connection
    - Example: `Grafana`, `Prod Observability`, `Analytics Platform`
@@ -213,7 +213,7 @@ You can add and configure any combination of Grafana services:
   <div style={{ padding: '16px' }}>
 
 1. Click **Save All** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your Grafana services
+2. Cardinal Desktop Application will verify connectivity to your Grafana services
 
 
 </div>

--- a/pages/vibeshield/connectors/httpmcp.mdx
+++ b/pages/vibeshield/connectors/httpmcp.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="HTTP MCP Server" />
 
 
-Connect Cardinal VibeShield to a custom HTTP MCP (Model Context Protocol) server for extended functionality.
+Connect Cardinal Desktop Application to a custom HTTP MCP (Model Context Protocol) server for extended functionality.
 
 ## Overview
 
@@ -64,14 +64,14 @@ HTTP MCP Server allows you to connect to custom Model Context Protocol servers o
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **HTTP MCP Server**
 3. Enter a **Name** for this MCP server
    - Example: `my-mcp-server`, `custom-tools`, `external-api`
    - This is a unique identifier used internally
 4. Enter a **Display Name** for this connection
    - Example: `MCP Server`, `Custom Tools`, `External API`
-   - This is displayed in the Cardinal VibeShield UI
+   - This is displayed in the Cardinal Desktop Application UI
 
 
 </div>
@@ -183,7 +183,7 @@ HTTP MCP Server allows you to connect to custom Model Context Protocol servers o
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your HTTP MCP server
+2. Cardinal Desktop Application will verify connectivity to your HTTP MCP server
 
 
 </div>

--- a/pages/vibeshield/connectors/index.mdx
+++ b/pages/vibeshield/connectors/index.mdx
@@ -4,7 +4,7 @@ import SupportCallout from '../../../components/SupportCallout';
 
 ## Connectors
 
-Connectors allow the Cardinal VibeShield to query and interact with your data sources by adding your connector credentials.
+Connectors allow the Cardinal Desktop Application to query and interact with your data sources by adding your connector credentials.
 
 <ConnectorGrid
   databases={[

--- a/pages/vibeshield/connectors/lakerunner.mdx
+++ b/pages/vibeshield/connectors/lakerunner.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Lakerunner" />
 
 
-Connect Cardinal VibeShield to Cardinal HQ's open-source data lake.
+Connect Cardinal Desktop Application to Cardinal HQ's open-source data lake.
 
 ## Overview
 
@@ -63,7 +63,7 @@ Lakerunner is CardinalHQ's open-source data lake solution that allows you to que
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Lakerunner**
 3. Enter a **Display Name** for this connection (e.g., "Lakerunner Prod", "Lakerunner Dev")
 
@@ -174,7 +174,7 @@ Lakerunner is CardinalHQ's open-source data lake solution that allows you to que
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your Lakerunner instance
+2. Cardinal Desktop Application will verify connectivity to your Lakerunner instance
 
 
 </div>

--- a/pages/vibeshield/connectors/lambda.mdx
+++ b/pages/vibeshield/connectors/lambda.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="AWS Lambda" />
 
 
-Connect Cardinal VibeShield to AWS Lambda for executing and integrating Lambda functions.
+Connect Cardinal Desktop Application to AWS Lambda for executing and integrating Lambda functions.
 
 ## Overview
 
@@ -62,7 +62,7 @@ AWS Lambda is a serverless computing service. With the Lambda connector, your AI
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **AWS Lambda**
 3. Enter a **Display Name** for this Lambda connection
    - Example: `AWS Lambda`, `Serverless Functions`, `Lambda Prod`
@@ -188,7 +188,7 @@ AWS Lambda is a serverless computing service. With the Lambda connector, your AI
 1. Review your configuration
 2. Click **Next** to continue
 3. Click **Save** to complete the configuration
-4. Cardinal VibeShield will verify access to your Lambda functions
+4. Cardinal Desktop Application will verify access to your Lambda functions
 
 
 </div>

--- a/pages/vibeshield/connectors/newrelic.mdx
+++ b/pages/vibeshield/connectors/newrelic.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="New Relic" />
 
 
-Connect Cardinal VibeShield to New Relic for monitoring logs, metrics, and traces.
+Connect Cardinal Desktop Application to New Relic for monitoring logs, metrics, and traces.
 
 ## Overview
 
@@ -65,7 +65,7 @@ New Relic is a comprehensive observability platform that provides insights into 
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **New Relic**
 3. Enter a **Display Name** for this connection
    - Example: "New Relic Prod", "New Relic Dev", "New Relic Staging"
@@ -188,7 +188,7 @@ New Relic is a comprehensive observability platform that provides insights into 
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify connectivity to your New Relic account
+2. Cardinal Desktop Application will verify connectivity to your New Relic account
 
 
 </div>

--- a/pages/vibeshield/connectors/postgres.mdx
+++ b/pages/vibeshield/connectors/postgres.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="PostgreSQL" />
 
 
-Connect Cardinal VibeShield to PostgreSQL databases, including Amazon RDS and Google Cloud SQL.
+Connect Cardinal Desktop Application to PostgreSQL databases, including Amazon RDS and Google Cloud SQL.
 
 ## Connection Details
 
@@ -79,7 +79,7 @@ chmod +x cloud-sql-proxy
 ./cloud-sql-proxy PROJECT_ID:REGION:INSTANCE_NAME
 ```
 
-Then connect to `localhost:5432` in Cardinal VibeShield.
+Then connect to `localhost:5432` in Cardinal Desktop Application.
 
 ## SSL Modes
 
@@ -101,7 +101,7 @@ Then connect to `localhost:5432` in Cardinal VibeShield.
 
 Once you have your connection details:
 
-1. In Cardinal VibeShield, go to **Datasources** and click **Add Datasource**
+1. In Cardinal Desktop Application, go to **Datasources** and click **Add Datasource**
 2. Select **PostgreSQL**
 3. Enter your connection details and click **Next**
 4. Select the **Database** you want to connect to

--- a/pages/vibeshield/connectors/prometheus.mdx
+++ b/pages/vibeshield/connectors/prometheus.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Prometheus" />
 
 
-Connect Cardinal VibeShield to Prometheus for monitoring and analyzing metrics.
+Connect Cardinal Desktop Application to Prometheus for monitoring and analyzing metrics.
 
 ## Overview
 
@@ -61,7 +61,7 @@ Prometheus is an open-source monitoring and alerting system that collects and st
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Prometheus**
 3. Enter a **Display Name** for this connection
    - Example: "Prometheus Prod", "Prometheus Dev", "Prometheus Staging"
@@ -137,7 +137,7 @@ Prometheus is an open-source monitoring and alerting system that collects and st
   <div style={{ padding: '16px' }}>
 
 1. Click **Connect** to verify connectivity to your Prometheus server
-2. Cardinal VibeShield will test the connection to your Prometheus instance
+2. Cardinal Desktop Application will test the connection to your Prometheus instance
 
 
 </div>

--- a/pages/vibeshield/connectors/slack.mdx
+++ b/pages/vibeshield/connectors/slack.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Slack" />
 
 
-Connect Cardinal VibeShield to Slack for sending notifications and messages to your Slack workspace.
+Connect Cardinal Desktop Application to Slack for sending notifications and messages to your Slack workspace.
 
 ## Overview
 
@@ -64,7 +64,7 @@ Slack is a messaging platform for team collaboration. With the Slack connector, 
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Slack**
 3. Go to [api.slack.com/apps](https://api.slack.com/apps) to create a new Slack app
 4. Click **"Create New App"** → **"From an app manifest"**
@@ -196,7 +196,7 @@ Slack is a messaging platform for team collaboration. With the Slack connector, 
   <div style={{ padding: '16px' }}>
 
 1. Click **Save** to complete the configuration
-2. Cardinal VibeShield will verify your Slack app credentials
+2. Cardinal Desktop Application will verify your Slack app credentials
 
 
 </div>

--- a/pages/vibeshield/connectors/snowflake.mdx
+++ b/pages/vibeshield/connectors/snowflake.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Snowflake" />
 
 
-Connect Cardinal VibeShield to Snowflake for querying and analyzing data in your Snowflake warehouse.
+Connect Cardinal Desktop Application to Snowflake for querying and analyzing data in your Snowflake warehouse.
 
 ## Overview
 
@@ -62,7 +62,7 @@ Snowflake is a cloud-based data warehouse platform. With the Snowflake connector
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Snowflake**
 3. Enter your **Account Identifier**
    - Format: `abc12345.us-east-1` or `abc12345.snowflakecomputing.com`
@@ -220,7 +220,7 @@ Snowflake is a cloud-based data warehouse platform. With the Snowflake connector
    - When disabled: credentials are stored locally on this device
    - When enabled: credentials are securely shared with your organization members
 3. Click **Save** to complete the configuration
-4. Cardinal VibeShield will verify your Snowflake connection
+4. Cardinal Desktop Application will verify your Snowflake connection
 
 
 </div>

--- a/pages/vibeshield/connectors/thanos.mdx
+++ b/pages/vibeshield/connectors/thanos.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../../components/SupportCallout';
 <ConnectorTitle name="Thanos" />
 
 
-Connect Cardinal VibeShield to Thanos for querying and analyzing long-term metrics storage.
+Connect Cardinal Desktop Application to Thanos for querying and analyzing long-term metrics storage.
 
 ## Overview
 
@@ -61,7 +61,7 @@ Thanos is an open-source project that extends Prometheus with long-term storage 
   </div>
   <div style={{ padding: '16px' }}>
 
-1. In Cardinal VibeShield, go to **Connectors** and click **Browse Connectors**
+1. In Cardinal Desktop Application, go to **Connectors** and click **Browse Connectors**
 2. Select **Thanos**
 3. Enter a **Display Name** for this connection
    - Example: "Thanos Prod", "Thanos Dev", "Thanos Staging"
@@ -137,7 +137,7 @@ Thanos is an open-source project that extends Prometheus with long-term storage 
   <div style={{ padding: '16px' }}>
 
 1. Click **Connect** to verify connectivity to your Thanos Query server
-2. Cardinal VibeShield will test the connection to your Thanos instance
+2. Cardinal Desktop Application will test the connection to your Thanos instance
 
 
 </div>

--- a/pages/vibeshield/get_started.mdx
+++ b/pages/vibeshield/get_started.mdx
@@ -16,6 +16,6 @@
 
 ![GitHub Connected](/signup/github-connected.png)
 
-6. You and your team can now start importing, customizing, and deploying Agents using the VibeShield desktop app. Click **Go to Download Page** to download and install the app on macOS, Windows, or Linux.
+6. You and your team can now start importing, customizing, and deploying Agents using the Cardinal Desktop Application. Click **Go to Download Page** to download and install the app on macOS, Windows, or Linux.
 
 7. Learn more [about the product,](/vibeshield/product) or how to [import one of Cardinal's pre-built Agents](/vibeshield/agents/datadog-release-agent) for common use cases that can be customized to fit your needs.

--- a/pages/vibeshield/index.mdx
+++ b/pages/vibeshield/index.mdx
@@ -1,8 +1,8 @@
 import SupportCallout from '../../components/SupportCallout';
 
-# Cardinal VibeShield
+# Cardinal Cardinal Desktop Application
 
-This section contains the full VibeShield overview, product walkthroughs, and connector guides.
+This section contains the full Cardinal Desktop Application overview, product walkthroughs, and connector guides.
 
 [Understand the assets and product features →](/vibeshield/product)
 
@@ -16,7 +16,7 @@ AI agents are autonomous assistants that can:
 - Provide insights and answer questions about your systems
 - Execute workflows based on triggers and conditions
 
-Cardinal VibeShield includes several pre-built agents for common use cases that can be imported and customized to fit your needs.
+Cardinal Cardinal Desktop Application includes several pre-built agents for common use cases that can be imported and customized to fit your needs.
 
 ## Getting Started
 

--- a/pages/vibeshield/overview.mdx
+++ b/pages/vibeshield/overview.mdx
@@ -1,8 +1,8 @@
 import SupportCallout from '../../components/SupportCallout';
 
-# Cardinal VibeShield
+# Cardinal Desktop Application
 
-Cardinal VibeShield is a [desktop application](http://www.cardinalhq.io) that enables you to build, configure, and deploy custom AI agents. These agents can autonomously monitor your infrastructure, answer questions about your systems, and take action based on deployment events.
+Cardinal Desktop Application is a [desktop application](http://www.cardinalhq.io) that enables you to build, configure, and deploy custom AI agents. These agents can autonomously monitor your infrastructure, answer questions about your systems, and take action based on deployment events.
 
 [Product Features](/vibeshield/product)
 

--- a/pages/vibeshield/product/launch-agents.mdx
+++ b/pages/vibeshield/product/launch-agents.mdx
@@ -9,7 +9,7 @@ Launching your Agents into your own cloud environment enables capabilities such 
 
 Launch Profiles are used to configure the cloud environment in which your Agents will be launched.
 
-1. In the VibeShield app, click on your name in the bottom-left corner, and select the **Organization Settings** menu item.
+1. In the Cardinal Desktop Application, click on your name in the bottom-left corner, and select the **Organization Settings** menu item.
 
 2. Select the **Launch Profiles** tab.
 
@@ -25,7 +25,7 @@ Launch Profiles are used to configure the cloud environment in which your Agents
 
 You are now ready to launch your Agents into your cloud environment.
 
-1. In the VibeShield app, click on your name in the bottom-left corner, and select the **Organization Settings** menu item.
+1. In the Cardinal Desktop Application, click on your name in the bottom-left corner, and select the **Organization Settings** menu item.
 
 2. Select the **Launch Agents** tab.
 


### PR DESCRIPTION
## Summary
- Rename all references from "VibeShield" to "Cardinal Desktop Application"
- Updates 28 files across docs, connectors, agents, and product guides

## Test plan
- [ ] Verify docs build successfully
- [ ] Check that navigation labels display correctly