### PR TITLE
Add Managed Collector documentation

### DIFF
--- a/components/ManagedCollectorDiagram.tsx
+++ b/components/ManagedCollectorDiagram.tsx
@@ -1,0 +1,304 @@
+import React from 'react';
+
+const ManagedCollectorDiagram: React.FC = () => {
+  return (
+    <div className="collector-diagram-container">
+      <svg
+        viewBox="0 0 800 500"
+        xmlns="http://www.w3.org/2000/svg"
+        className="collector-diagram"
+      >
+        {/* Background */}
+        <rect width="800" height="500" className="diagram-bg" />
+
+        {/* Kubernetes Cluster boundary */}
+        <rect
+          x="30"
+          y="30"
+          width="540"
+          height="440"
+          rx="12"
+          className="cluster-boundary"
+        />
+        <text x="50" y="58" className="cluster-label">Kubernetes Cluster</text>
+
+        {/* Node 1 */}
+        <rect x="50" y="80" width="230" height="180" rx="8" className="node-box" />
+        <text x="70" y="105" className="node-label">Node 1</text>
+
+        {/* Pods on Node 1 */}
+        <rect x="70" y="120" width="60" height="40" rx="4" className="pod-box" />
+        <text x="100" y="145" className="pod-label">Pod</text>
+        <rect x="140" y="120" width="60" height="40" rx="4" className="pod-box" />
+        <text x="170" y="145" className="pod-label">Pod</text>
+        <rect x="70" y="170" width="60" height="40" rx="4" className="pod-box" />
+        <text x="100" y="195" className="pod-label">Pod</text>
+
+        {/* Agent Collector on Node 1 */}
+        <rect x="150" y="170" width="110" height="50" rx="6" className="agent-box" />
+        <text x="205" y="192" className="collector-label">Agent</text>
+        <text x="205" y="208" className="collector-label">Collector</text>
+
+        {/* Arrows from pods to agent */}
+        <path d="M130 140 L160 185" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M170 160 L185 175" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M130 190 L150 195" className="arrow-line" markerEnd="url(#arrowhead)" />
+
+        {/* Node 2 */}
+        <rect x="50" y="280" width="230" height="180" rx="8" className="node-box" />
+        <text x="70" y="305" className="node-label">Node 2</text>
+
+        {/* Pods on Node 2 */}
+        <rect x="70" y="320" width="60" height="40" rx="4" className="pod-box" />
+        <text x="100" y="345" className="pod-label">Pod</text>
+        <rect x="140" y="320" width="60" height="40" rx="4" className="pod-box" />
+        <text x="170" y="345" className="pod-label">Pod</text>
+
+        {/* Agent Collector on Node 2 */}
+        <rect x="150" y="370" width="110" height="50" rx="6" className="agent-box" />
+        <text x="205" y="392" className="collector-label">Agent</text>
+        <text x="205" y="408" className="collector-label">Collector</text>
+
+        {/* Arrows from pods to agent on node 2 */}
+        <path d="M130 360 L175 375" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M170 360 L190 375" className="arrow-line" markerEnd="url(#arrowhead)" />
+
+        {/* Polling Collector */}
+        <rect x="320" y="120" width="120" height="70" rx="6" className="polling-box" />
+        <text x="380" y="150" className="collector-label">Polling</text>
+        <text x="380" y="168" className="collector-label">Collector</text>
+
+        {/* K8s API, Prometheus targets */}
+        <rect x="330" y="220" width="100" height="35" rx="4" className="source-box" />
+        <text x="380" y="242" className="source-label">K8s API</text>
+        <rect x="330" y="265" width="100" height="35" rx="4" className="source-box" />
+        <text x="380" y="287" className="source-label">Prometheus</text>
+        <text x="380" y="300" className="source-label-small">targets</text>
+
+        {/* Arrows from sources to polling */}
+        <path d="M380 220 L380 190" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M380 265 L380 190" className="arrow-line" markerEnd="url(#arrowhead)" />
+
+        {/* Gateway Collector */}
+        <rect x="320" y="360" width="120" height="80" rx="6" className="gateway-box" />
+        <text x="380" y="395" className="gateway-label">Gateway</text>
+        <text x="380" y="415" className="gateway-label">Collector</text>
+
+        {/* Arrows to Gateway */}
+        <path d="M260 195 L320 395" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M260 395 L320 400" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M380 190 L380 360" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+
+        {/* External destinations */}
+        {/* Lakerunner / Object Storage */}
+        <rect x="600" y="300" width="160" height="60" rx="8" className="destination-box" />
+        <text x="680" y="325" className="destination-label">Lakerunner</text>
+        <text x="680" y="345" className="destination-label-small">(Object Storage)</text>
+
+        {/* OTLP Destination */}
+        <rect x="600" y="400" width="160" height="60" rx="8" className="destination-box" />
+        <text x="680" y="425" className="destination-label">OTLP</text>
+        <text x="680" y="445" className="destination-label-small">Destination</text>
+
+        {/* Arrows from Gateway to destinations */}
+        <path d="M440 385 L600 330" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M440 410 L600 430" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+
+        {/* Arrow definitions */}
+        <defs>
+          <marker
+            id="arrowhead"
+            markerWidth="10"
+            markerHeight="7"
+            refX="9"
+            refY="3.5"
+            orient="auto"
+          >
+            <polygon points="0 0, 10 3.5, 0 7" className="arrowhead" />
+          </marker>
+        </defs>
+      </svg>
+
+      <style jsx>{`
+        .collector-diagram-container {
+          margin: 2rem 0;
+          padding: 1rem;
+          border-radius: 12px;
+          background: var(--diagram-container-bg);
+        }
+        .collector-diagram {
+          width: 100%;
+          max-width: 800px;
+          height: auto;
+        }
+        .diagram-bg {
+          fill: var(--diagram-bg);
+        }
+        .cluster-boundary {
+          fill: none;
+          stroke: var(--cluster-stroke);
+          stroke-width: 2;
+          stroke-dasharray: 8 4;
+        }
+        .cluster-label {
+          font-size: 14px;
+          font-weight: 600;
+          fill: var(--text-secondary);
+        }
+        .node-box {
+          fill: var(--node-bg);
+          stroke: var(--node-stroke);
+          stroke-width: 1.5;
+        }
+        .node-label {
+          font-size: 12px;
+          font-weight: 600;
+          fill: var(--text-primary);
+        }
+        .pod-box {
+          fill: var(--pod-bg);
+          stroke: var(--pod-stroke);
+          stroke-width: 1;
+        }
+        .pod-label {
+          font-size: 10px;
+          fill: var(--text-secondary);
+          text-anchor: middle;
+        }
+        .agent-box {
+          fill: var(--agent-bg);
+          stroke: var(--agent-stroke);
+          stroke-width: 2;
+        }
+        .polling-box {
+          fill: var(--polling-bg);
+          stroke: var(--polling-stroke);
+          stroke-width: 2;
+        }
+        .gateway-box {
+          fill: var(--gateway-bg);
+          stroke: var(--gateway-stroke);
+          stroke-width: 2;
+        }
+        .collector-label {
+          font-size: 11px;
+          font-weight: 600;
+          fill: var(--collector-text);
+          text-anchor: middle;
+        }
+        .gateway-label {
+          font-size: 13px;
+          font-weight: 700;
+          fill: var(--gateway-text);
+          text-anchor: middle;
+        }
+        .source-box {
+          fill: var(--source-bg);
+          stroke: var(--source-stroke);
+          stroke-width: 1;
+        }
+        .source-label {
+          font-size: 10px;
+          fill: var(--text-secondary);
+          text-anchor: middle;
+        }
+        .source-label-small {
+          font-size: 8px;
+          fill: var(--text-muted);
+          text-anchor: middle;
+        }
+        .destination-box {
+          fill: var(--destination-bg);
+          stroke: var(--destination-stroke);
+          stroke-width: 2;
+        }
+        .destination-label {
+          font-size: 12px;
+          font-weight: 600;
+          fill: var(--destination-text);
+          text-anchor: middle;
+        }
+        .destination-label-small {
+          font-size: 10px;
+          fill: var(--destination-text-secondary);
+          text-anchor: middle;
+        }
+        .arrow-line {
+          fill: none;
+          stroke: var(--arrow-color);
+          stroke-width: 1.5;
+        }
+        .arrow-line-thick {
+          fill: none;
+          stroke: var(--arrow-color-strong);
+          stroke-width: 2.5;
+        }
+        .arrowhead {
+          fill: var(--arrow-color-strong);
+        }
+
+        /* Light mode (default) */
+        :global(:root) {
+          --diagram-container-bg: #f8f9fa;
+          --diagram-bg: #ffffff;
+          --cluster-stroke: #6b7280;
+          --text-primary: #1f2937;
+          --text-secondary: #4b5563;
+          --text-muted: #9ca3af;
+          --node-bg: #f3f4f6;
+          --node-stroke: #d1d5db;
+          --pod-bg: #e0e7ff;
+          --pod-stroke: #a5b4fc;
+          --agent-bg: #dbeafe;
+          --agent-stroke: #3b82f6;
+          --polling-bg: #fef3c7;
+          --polling-stroke: #f59e0b;
+          --gateway-bg: #dcfce7;
+          --gateway-stroke: #22c55e;
+          --gateway-text: #166534;
+          --collector-text: #1e40af;
+          --source-bg: #f5f5f5;
+          --source-stroke: #a1a1aa;
+          --destination-bg: #fff7ed;
+          --destination-stroke: #ff5722;
+          --destination-text: #9a3412;
+          --destination-text-secondary: #c2410c;
+          --arrow-color: #9ca3af;
+          --arrow-color-strong: #6b7280;
+        }
+
+        /* Dark mode */
+        :global(.dark) {
+          --diagram-container-bg: #1a1a2e;
+          --diagram-bg: #16213e;
+          --cluster-stroke: #64748b;
+          --text-primary: #f1f5f9;
+          --text-secondary: #cbd5e1;
+          --text-muted: #64748b;
+          --node-bg: #1e293b;
+          --node-stroke: #475569;
+          --pod-bg: #312e81;
+          --pod-stroke: #6366f1;
+          --agent-bg: #1e3a5f;
+          --agent-stroke: #60a5fa;
+          --polling-bg: #451a03;
+          --polling-stroke: #fbbf24;
+          --gateway-bg: #14532d;
+          --gateway-stroke: #4ade80;
+          --gateway-text: #bbf7d0;
+          --collector-text: #93c5fd;
+          --source-bg: #27272a;
+          --source-stroke: #71717a;
+          --destination-bg: #431407;
+          --destination-stroke: #ff8a5c;
+          --destination-text: #fed7aa;
+          --destination-text-secondary: #fdba74;
+          --arrow-color: #64748b;
+          --arrow-color-strong: #94a3b8;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default ManagedCollectorDiagram;

--- a/components/ManagedCollectorDiagram.tsx
+++ b/components/ManagedCollectorDiagram.tsx
@@ -4,105 +4,116 @@ const ManagedCollectorDiagram: React.FC = () => {
   return (
     <div className="collector-diagram-container">
       <svg
-        viewBox="0 0 800 500"
+        viewBox="0 0 900 520"
         xmlns="http://www.w3.org/2000/svg"
         className="collector-diagram"
       >
         {/* Background */}
-        <rect width="800" height="500" className="diagram-bg" />
+        <rect width="900" height="520" className="diagram-bg" />
 
         {/* Kubernetes Cluster boundary */}
         <rect
-          x="30"
-          y="30"
-          width="540"
-          height="440"
+          x="20"
+          y="20"
+          width="580"
+          height="480"
           rx="12"
           className="cluster-boundary"
         />
-        <text x="50" y="58" className="cluster-label">Kubernetes Cluster</text>
+        <text x="40" y="48" className="cluster-label">Kubernetes Cluster</text>
+
+        {/* === LEFT COLUMN: Nodes with Agent Collectors === */}
 
         {/* Node 1 */}
-        <rect x="50" y="80" width="230" height="180" rx="8" className="node-box" />
-        <text x="70" y="105" className="node-label">Node 1</text>
+        <rect x="40" y="70" width="200" height="190" rx="8" className="node-box" />
+        <text x="60" y="95" className="node-label">Node 1</text>
 
-        {/* Pods on Node 1 */}
-        <rect x="70" y="120" width="60" height="40" rx="4" className="pod-box" />
-        <text x="100" y="145" className="pod-label">Pod</text>
-        <rect x="140" y="120" width="60" height="40" rx="4" className="pod-box" />
-        <text x="170" y="145" className="pod-label">Pod</text>
-        <rect x="70" y="170" width="60" height="40" rx="4" className="pod-box" />
-        <text x="100" y="195" className="pod-label">Pod</text>
+        {/* Items on Node 1 */}
+        <rect x="55" y="110" width="50" height="35" rx="4" className="pod-box" />
+        <text x="80" y="125" className="pod-label">Node</text>
+        <text x="80" y="137" className="pod-label">Metrics</text>
+        <rect x="115" y="110" width="50" height="35" rx="4" className="pod-box" />
+        <text x="140" y="132" className="pod-label">Pod</text>
+        <rect x="175" y="110" width="50" height="35" rx="4" className="pod-box" />
+        <text x="200" y="132" className="pod-label">Pod</text>
 
         {/* Agent Collector on Node 1 */}
-        <rect x="150" y="170" width="110" height="50" rx="6" className="agent-box" />
-        <text x="205" y="192" className="collector-label">Agent</text>
-        <text x="205" y="208" className="collector-label">Collector</text>
+        <rect x="80" y="165" width="120" height="50" rx="6" className="agent-box" />
+        <text x="140" y="187" className="collector-label">Agent</text>
+        <text x="140" y="203" className="collector-label">Collector</text>
 
         {/* Arrows from pods to agent */}
-        <path d="M130 140 L160 185" className="arrow-line" markerEnd="url(#arrowhead)" />
-        <path d="M170 160 L185 175" className="arrow-line" markerEnd="url(#arrowhead)" />
-        <path d="M130 190 L150 195" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M80 145 L100 165" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M140 145 L140 165" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M200 145 L180 165" className="arrow-line" markerEnd="url(#arrowhead)" />
 
         {/* Node 2 */}
-        <rect x="50" y="280" width="230" height="180" rx="8" className="node-box" />
-        <text x="70" y="305" className="node-label">Node 2</text>
+        <rect x="40" y="290" width="200" height="190" rx="8" className="node-box" />
+        <text x="60" y="315" className="node-label">Node 2</text>
 
-        {/* Pods on Node 2 */}
-        <rect x="70" y="320" width="60" height="40" rx="4" className="pod-box" />
-        <text x="100" y="345" className="pod-label">Pod</text>
-        <rect x="140" y="320" width="60" height="40" rx="4" className="pod-box" />
-        <text x="170" y="345" className="pod-label">Pod</text>
+        {/* Items on Node 2 */}
+        <rect x="55" y="330" width="50" height="35" rx="4" className="pod-box" />
+        <text x="80" y="345" className="pod-label">Node</text>
+        <text x="80" y="357" className="pod-label">Metrics</text>
+        <rect x="115" y="330" width="50" height="35" rx="4" className="pod-box" />
+        <text x="140" y="352" className="pod-label">Pod</text>
+        <rect x="175" y="330" width="50" height="35" rx="4" className="pod-box" />
+        <text x="200" y="352" className="pod-label">Pod</text>
 
         {/* Agent Collector on Node 2 */}
-        <rect x="150" y="370" width="110" height="50" rx="6" className="agent-box" />
-        <text x="205" y="392" className="collector-label">Agent</text>
-        <text x="205" y="408" className="collector-label">Collector</text>
+        <rect x="80" y="385" width="120" height="50" rx="6" className="agent-box" />
+        <text x="140" y="407" className="collector-label">Agent</text>
+        <text x="140" y="423" className="collector-label">Collector</text>
 
         {/* Arrows from pods to agent on node 2 */}
-        <path d="M130 360 L175 375" className="arrow-line" markerEnd="url(#arrowhead)" />
-        <path d="M170 360 L190 375" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M80 365 L100 385" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M140 365 L140 385" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M200 365 L180 385" className="arrow-line" markerEnd="url(#arrowhead)" />
+
+        {/* === MIDDLE COLUMN: Polling Collector === */}
+
+        {/* Data sources for Polling - horizontal layout */}
+        <rect x="270" y="70" width="100" height="50" rx="4" className="source-box" />
+        <text x="320" y="100" className="source-label">K8s API</text>
+
+        <rect x="390" y="70" width="100" height="50" rx="4" className="source-box" />
+        <text x="440" y="92" className="source-label">Prometheus</text>
+        <text x="440" y="107" className="source-label-small">targets</text>
 
         {/* Polling Collector */}
-        <rect x="320" y="120" width="120" height="70" rx="6" className="polling-box" />
-        <text x="380" y="150" className="collector-label">Polling</text>
-        <text x="380" y="168" className="collector-label">Collector</text>
-
-        {/* K8s API, Prometheus targets */}
-        <rect x="330" y="220" width="100" height="35" rx="4" className="source-box" />
-        <text x="380" y="242" className="source-label">K8s API</text>
-        <rect x="330" y="265" width="100" height="35" rx="4" className="source-box" />
-        <text x="380" y="287" className="source-label">Prometheus</text>
-        <text x="380" y="300" className="source-label-small">targets</text>
+        <rect x="305" y="160" width="130" height="65" rx="6" className="polling-box" />
+        <text x="370" y="188" className="collector-label">Polling</text>
+        <text x="370" y="206" className="collector-label">Collector</text>
 
         {/* Arrows from sources to polling */}
-        <path d="M380 220 L380 190" className="arrow-line" markerEnd="url(#arrowhead)" />
-        <path d="M380 265 L380 190" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M320 120 L350 160" className="arrow-line" markerEnd="url(#arrowhead)" />
+        <path d="M440 120 L390 160" className="arrow-line" markerEnd="url(#arrowhead)" />
 
-        {/* Gateway Collector */}
-        <rect x="320" y="360" width="120" height="80" rx="6" className="gateway-box" />
-        <text x="380" y="395" className="gateway-label">Gateway</text>
-        <text x="380" y="415" className="gateway-label">Collector</text>
+        {/* === GATEWAY COLLECTOR (center bottom) === */}
+        <rect x="305" y="380" width="130" height="75" rx="6" className="gateway-box" />
+        <text x="370" y="412" className="gateway-label">Gateway</text>
+        <text x="370" y="432" className="gateway-label">Collector</text>
 
         {/* Arrows to Gateway */}
-        <path d="M260 195 L320 395" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
-        <path d="M260 395 L320 400" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
-        <path d="M380 190 L380 360" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M200 190 L305 405" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M200 410 L305 418" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M370 225 L370 380" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
 
-        {/* External destinations */}
-        {/* Lakerunner / Object Storage */}
-        <rect x="600" y="300" width="160" height="60" rx="8" className="destination-box" />
-        <text x="680" y="325" className="destination-label">Lakerunner</text>
-        <text x="680" y="345" className="destination-label-small">(Object Storage)</text>
+        {/* === RIGHT SIDE: Destinations (outside cluster) === */}
+
+        {/* Lakerunner */}
+        <rect x="640" y="320" width="160" height="60" rx="8" className="destination-box" />
+        <text x="720" y="345" className="destination-label">Lakerunner</text>
+        <text x="720" y="363" className="destination-label-small">(Object Storage)</text>
 
         {/* OTLP Destination */}
-        <rect x="600" y="400" width="160" height="60" rx="8" className="destination-box" />
-        <text x="680" y="425" className="destination-label">OTLP</text>
-        <text x="680" y="445" className="destination-label-small">Destination</text>
+        <rect x="640" y="410" width="160" height="60" rx="8" className="destination-box" />
+        <text x="720" y="435" className="destination-label">OTLP</text>
+        <text x="720" y="453" className="destination-label-small">Destination</text>
 
         {/* Arrows from Gateway to destinations */}
-        <path d="M440 385 L600 330" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
-        <path d="M440 410 L600 430" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M435 400 L640 350" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
+        <path d="M435 430 L640 440" className="arrow-line-thick" markerEnd="url(#arrowhead)" />
 
         {/* Arrow definitions */}
         <defs>
@@ -128,7 +139,7 @@ const ManagedCollectorDiagram: React.FC = () => {
         }
         .collector-diagram {
           width: 100%;
-          max-width: 800px;
+          max-width: 900px;
           height: auto;
         }
         .diagram-bg {
@@ -181,13 +192,13 @@ const ManagedCollectorDiagram: React.FC = () => {
           stroke-width: 2;
         }
         .collector-label {
-          font-size: 11px;
+          font-size: 12px;
           font-weight: 600;
           fill: var(--collector-text);
           text-anchor: middle;
         }
         .gateway-label {
-          font-size: 13px;
+          font-size: 14px;
           font-weight: 700;
           fill: var(--gateway-text);
           text-anchor: middle;
@@ -195,15 +206,15 @@ const ManagedCollectorDiagram: React.FC = () => {
         .source-box {
           fill: var(--source-bg);
           stroke: var(--source-stroke);
-          stroke-width: 1;
+          stroke-width: 1.5;
         }
         .source-label {
-          font-size: 10px;
+          font-size: 11px;
           fill: var(--text-secondary);
           text-anchor: middle;
         }
         .source-label-small {
-          font-size: 8px;
+          font-size: 9px;
           fill: var(--text-muted);
           text-anchor: middle;
         }
@@ -213,7 +224,7 @@ const ManagedCollectorDiagram: React.FC = () => {
           stroke-width: 2;
         }
         .destination-label {
-          font-size: 12px;
+          font-size: 13px;
           font-weight: 600;
           fill: var(--destination-text);
           text-anchor: middle;

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -1,5 +1,6 @@
 {
   "index": "Welcome",
   "vibeshield": "Cardinal Desktop Application",
-  "lakerunner": "Lakerunner"
+  "lakerunner": "Lakerunner",
+  "managed-collector": "Managed Collector"
 }

--- a/pages/managed-collector/_meta.json
+++ b/pages/managed-collector/_meta.json
@@ -1,0 +1,4 @@
+{
+  "index": "Overview",
+  "connectors": "Connectors"
+}

--- a/pages/managed-collector/connectors/_meta.json
+++ b/pages/managed-collector/connectors/_meta.json
@@ -1,0 +1,5 @@
+{
+  "index": "Overview",
+  "sources": "Sources",
+  "destinations": "Destinations"
+}

--- a/pages/managed-collector/connectors/destinations.mdx
+++ b/pages/managed-collector/connectors/destinations.mdx
@@ -1,0 +1,35 @@
+# Destinations
+
+Destinations (exporters) define where your processed telemetry data is sent after passing through the pipeline.
+
+---
+
+## OTLP
+
+Sends telemetry data to [OpenTelemetry](https://opentelemetry.io/) compatible endpoints using gRPC. This is the recommended exporter for most OpenTelemetry backends.
+
+**Supports:** Metrics, Logs, Traces
+
+---
+
+## OTLP HTTP
+
+Sends telemetry data to [OpenTelemetry](https://opentelemetry.io/) compatible endpoints using HTTP/JSON. Use this when gRPC is not available or when sending through HTTP proxies.
+
+**Supports:** Metrics, Logs, Traces
+
+---
+
+## Debug Exporter
+
+Outputs telemetry data for debugging and testing purposes. Useful during pipeline development to verify data is flowing correctly.
+
+**Supports:** Metrics, Logs, Traces
+
+---
+
+## CHQ IPC
+
+Cardinal internal pipeline communication. Used for routing telemetry between pipeline components within the Cardinal infrastructure.
+
+**Supports:** Metrics, Logs, Traces

--- a/pages/managed-collector/connectors/index.mdx
+++ b/pages/managed-collector/connectors/index.mdx
@@ -1,0 +1,34 @@
+# Connectors
+
+Cardinal Managed Collectors support a variety of telemetry connectors that enable you to receive data from multiple sources and forward it to various destinations.
+
+## Sources (Receivers)
+
+Sources define how telemetry data enters your collector pipeline.
+
+| Source | Description |
+|--------|-------------|
+| [OTLP](./sources#otlp) | OpenTelemetry Protocol (gRPC and HTTP) |
+| [Prometheus](./sources#prometheus) | Prometheus scrape endpoint |
+| [Prometheus Remote Write](./sources#prometheus-remote-write) | Prometheus remote write receiver |
+| [StatsD](./sources#statsd) | StatsD metrics receiver |
+| [Logstash](./sources#logstash) | Elastic Logstash log receiver |
+| [Filelog](./sources#filelog) | File-based log collection |
+| [AWS Firehose Metrics](./sources#aws-firehose-metrics) | Amazon Kinesis Data Firehose metrics |
+| [Kubernetes Metrics](./sources#kubernetes-metrics) | Kubernetes pod and container metrics |
+| [Kubernetes Cluster Metrics](./sources#kubernetes-cluster-metrics) | Kubernetes cluster-level metrics |
+| [Kubernetes Events](./sources#kubernetes-events) | Kubernetes cluster events |
+| [CHQ IPC](./sources#chq-ipc) | Cardinal internal pipeline communication |
+
+## Destinations (Exporters)
+
+Destinations define where your processed telemetry data is sent after passing through the pipeline.
+
+| Destination | Description |
+|-------------|-------------|
+| [OTLP](./destinations#otlp) | OpenTelemetry Protocol (gRPC) |
+| [OTLP HTTP](./destinations#otlp-http) | OpenTelemetry Protocol (HTTP) |
+| [Debug Exporter](./destinations#debug-exporter) | Debug output for testing |
+| [CHQ IPC](./destinations#chq-ipc) | Cardinal internal pipeline communication |
+
+If you're looking for a connector that isn't listed here, please [email us](mailto:support@cardinalhq.io) and let us know!

--- a/pages/managed-collector/connectors/sources.mdx
+++ b/pages/managed-collector/connectors/sources.mdx
@@ -1,0 +1,91 @@
+# Sources
+
+Sources (receivers) define how telemetry data enters your collector pipeline. Configure these to receive data from your applications and infrastructure.
+
+---
+
+## OTLP
+
+Receives telemetry data via gRPC or HTTP in the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/) format. This is the recommended receiver for OpenTelemetry-instrumented applications.
+
+**Supports:** Metrics, Logs, Traces
+
+---
+
+## Prometheus
+
+Scrapes metrics from [Prometheus](https://prometheus.io/) endpoints. Use this to collect metrics from applications that expose Prometheus-format metrics.
+
+**Supports:** Metrics
+
+---
+
+## Prometheus Remote Write
+
+Receives metrics from [Prometheus](https://prometheus.io/) servers using Remote Write forwarding. Configure your Prometheus server to send metrics to the collector.
+
+**Supports:** Metrics
+
+---
+
+## StatsD
+
+Receives metrics in [StatsD](https://github.com/statsd/statsd) format. Compatible with applications using StatsD client libraries.
+
+**Supports:** Metrics
+
+---
+
+## Logstash
+
+Receives logs from [Elastic Logstash](https://www.elastic.co/logstash) pipelines via TCP.
+
+**Supports:** Logs
+
+---
+
+## Filelog
+
+Collects logs from files on the local filesystem. Useful for collecting application logs written to disk, container logs, and system logs.
+
+**Supports:** Logs
+
+---
+
+## AWS Firehose Metrics
+
+Receives metrics from [Amazon Kinesis Data Firehose](https://aws.amazon.com/firehose/). Use this to ingest CloudWatch metrics or other AWS telemetry data.
+
+**Supports:** Metrics
+
+---
+
+## Kubernetes Metrics
+
+Collects pod and container-level metrics from Kubernetes. Automatically discovers and scrapes metrics from pods running in the cluster.
+
+**Supports:** Metrics
+
+---
+
+## Kubernetes Cluster Metrics
+
+Collects cluster-level metrics from Kubernetes, including node metrics, resource quotas, and cluster state information.
+
+**Supports:** Metrics
+
+---
+
+## Kubernetes Events
+
+Captures Kubernetes cluster events such as pod scheduling, container starts/stops, and other cluster activities. Useful for correlating infrastructure events with application telemetry.
+
+**Supports:** Logs (Events)
+
+---
+
+## CHQ IPC
+
+Cardinal internal pipeline communication. Used for routing telemetry between pipeline components within the Cardinal infrastructure.
+
+**Supports:** Metrics, Logs, Traces

--- a/pages/managed-collector/index.mdx
+++ b/pages/managed-collector/index.mdx
@@ -1,0 +1,66 @@
+import ExpandableImage from "../../components/ExpandableImage"
+
+# Managed Collector
+
+Cardinal Managed Collectors are a remotely configurable layer on top of the OpenTelemetry Collector, designed to simplify and streamline how you gather, process, and send telemetry data. By leveraging the Cardinal Managed Collector, you gain operational visibility and control over every stage of your telemetry pipeline—without manually configuring or maintaining collectors across your environment.
+
+## Pipeline Telemetry & Remote Management
+
+At the heart of Cardinal's Managed Collectors are **Collector Pipelines**, which define how telemetry flows from sources to destinations through a series of processors and rules. With the Managed Collector, you can:
+
+- **Add or Remove OpenTelemetry Sources (Receivers):** Dynamically introduce new data streams (e.g., from applications, infrastructure, or services) or stop unwanted ones—all without touching the underlying infrastructure.
+- **Manage Sinks (Exporters):** Seamlessly re-route telemetry data to different backends (e.g., logging services, metrics storage, or trace analysis tools) at any time. Quickly respond to business needs, compliance requirements, or cost considerations.
+- **Utilize Managed Processors (Rules):** Apply powerful transformations, enrichments, or filters to your telemetry data with simple configuration changes. Whether you're masking PII, dropping noisy metrics, extracting tags from logs, or sampling traces, these rules ensure that only the most valuable data reaches your destinations.
+
+All of these changes are made via the [Cardinal UI](https://app.cardinalhq.io), ensuring that collectors remain up-to-date and aligned with your current observability strategy. There's no need to redeploy or manually reconfigure collectors at the host level—the Managed Collector handles it all remotely.
+
+## Node and Rule-Level Statistics
+
+Cardinal doesn't just orchestrate the pipeline; it also provides granular insights into its operation:
+
+- **Node Stats:** Keep track of system-level metrics (CPU usage, memory consumption) and understand collector health in real-time. This ensures you have the operational transparency needed to maintain performance and reliability.
+
+- **Rule Stats & Pipeline Telemetry:** Monitor how rules affect your data. For example, track how much data is being filtered out, how often tags are being extracted, or how effective your sampling strategies are. This data helps you fine-tune your pipelines for cost savings, compliance, and meaningful analytics.
+
+## Collector Telemetry Insights
+
+In addition to managing and transforming data, Cardinal's managed collectors emit telemetry about themselves. This includes information on:
+
+- **Pipeline Behavior:** Understand how data moves through sources, rules, and destinations.
+- **Resource Utilization:** Gain visibility into CPU, memory, and network usage, ensuring collectors run smoothly and cost-effectively.
+- **Rule Efficacy:** See the impact of each rule, quantifying how many data points are dropped, tagged, masked, or transformed.
+
+By capturing and exposing these operational metrics, the Managed Collector empowers you to adopt a data-driven approach to collector management, helping you adapt quickly as your environment, data volume, or compliance requirements evolve.
+
+## Pipeline Rules
+
+Pipeline rules are flexible, user-defined transformations and filters applied to your telemetry data as it passes through the pipeline. By shaping and refining data before it lands in your storage or monitoring tools, rules help you:
+
+- Control costs by removing unnecessary data
+- Enhance data quality and context by adding tags or extracting metrics
+- Improve privacy by masking or dropping sensitive information
+- Streamline observability efforts, making it easier to investigate and understand system behavior
+
+### Available Rule Types
+
+| Rule Type | Description |
+|-----------|-------------|
+| **PII Removal/Masking** | Remove or obscure sensitive Personally Identifiable Information from your telemetry |
+| **Extract Metrics** | Convert log fields into metrics on the fly for easier aggregation and alerting |
+| **Custom OTTL** | Write custom conditions and statements using OpenTelemetry Transformation Language |
+| **Filter** | Completely remove certain telemetry items based on defined conditions |
+| **Drop Tags** | Remove high-cardinality tags or dimensions that inflate cost and complexity |
+| **Add Tags** | Enrich telemetry by adding tags (key-value pairs) based on conditions |
+| **Sampling** | Reduce telemetry volume by sampling logs—either randomly or proportionally |
+| **Extract Tags** | Parse unstructured log messages to extract variable parts into structured tags |
+
+## Getting Started
+
+To get started with Managed Collectors:
+
+1. Navigate to **Collector Pipelines** in the [Cardinal UI](https://app.cardinalhq.io)
+2. Add your desired [Connectors](/managed-collector/connectors) (sources and destinations)
+3. Configure processing rules to shape your telemetry data
+4. Deploy or update your collector using the provided Helm chart
+
+Pipelines are fully managed through the Cardinal UI, and Collectors continuously stay up-to-date with the latest Pipeline configurations.

--- a/pages/managed-collector/index.mdx
+++ b/pages/managed-collector/index.mdx
@@ -1,58 +1,82 @@
-import ExpandableImage from "../../components/ExpandableImage"
+import ManagedCollectorDiagram from "../../components/ManagedCollectorDiagram"
 
 # Managed Collector
 
 Cardinal Managed Collectors are a remotely configurable layer on top of the OpenTelemetry Collector, designed to simplify and streamline how you gather, process, and send telemetry data. By leveraging the Cardinal Managed Collector, you gain operational visibility and control over every stage of your telemetry pipeline—without manually configuring or maintaining collectors across your environment.
 
-## Pipeline Telemetry & Remote Management
+## Architecture
 
-At the heart of Cardinal's Managed Collectors are **Collector Pipelines**, which define how telemetry flows from sources to destinations through a series of processors and rules. With the Managed Collector, you can:
+The Managed Collector uses a distributed architecture designed for Kubernetes environments, with three collector types working together:
 
-- **Add or Remove OpenTelemetry Sources (Receivers):** Dynamically introduce new data streams (e.g., from applications, infrastructure, or services) or stop unwanted ones—all without touching the underlying infrastructure.
-- **Manage Sinks (Exporters):** Seamlessly re-route telemetry data to different backends (e.g., logging services, metrics storage, or trace analysis tools) at any time. Quickly respond to business needs, compliance requirements, or cost considerations.
-- **Utilize Managed Processors (Rules):** Apply powerful transformations, enrichments, or filters to your telemetry data with simple configuration changes. Whether you're masking PII, dropping noisy metrics, extracting tags from logs, or sampling traces, these rules ensure that only the most valuable data reaches your destinations.
+<ManagedCollectorDiagram />
 
-All of these changes are made via the [Cardinal UI](https://app.cardinalhq.io), ensuring that collectors remain up-to-date and aligned with your current observability strategy. There's no need to redeploy or manually reconfigure collectors at the host level—the Managed Collector handles it all remotely.
+### Collector Types
 
-## Node and Rule-Level Statistics
+**Gateway Collector**
 
-Cardinal doesn't just orchestrate the pipeline; it also provides granular insights into its operation:
+The Gateway Collector is the central aggregation point for all telemetry within a Kubernetes cluster. It receives data from Agent and Polling collectors, applies pipeline rules, and forwards processed telemetry to external destinations. The Gateway can simultaneously write to:
+- **Lakerunner** (object storage) for long-term retention and analytics
+- **OTLP destinations** for real-time monitoring and alerting
 
-- **Node Stats:** Keep track of system-level metrics (CPU usage, memory consumption) and understand collector health in real-time. This ensures you have the operational transparency needed to maintain performance and reliability.
+**Agent Collector**
 
-- **Rule Stats & Pipeline Telemetry:** Monitor how rules affect your data. For example, track how much data is being filtered out, how often tags are being extracted, or how effective your sampling strategies are. This data helps you fine-tune your pipelines for cost savings, compliance, and meaningful analytics.
+Agent Collectors run as a DaemonSet, with one instance on every node in the cluster. They are responsible for:
+- Receiving telemetry from pods running on the node (distributing collection workload)
+- Monitoring node-level metrics (CPU, memory, disk, network)
+- Collecting container logs and system logs
+- Forwarding all collected data to the Gateway Collector
 
-## Collector Telemetry Insights
+By running on each node, Agent Collectors ensure that telemetry collection is distributed and that pods communicate with a local collector, minimizing network overhead.
 
-In addition to managing and transforming data, Cardinal's managed collectors emit telemetry about themselves. This includes information on:
+**Polling Collector**
 
-- **Pipeline Behavior:** Understand how data moves through sources, rules, and destinations.
-- **Resource Utilization:** Gain visibility into CPU, memory, and network usage, ensuring collectors run smoothly and cost-effectively.
-- **Rule Efficacy:** See the impact of each rule, quantifying how many data points are dropped, tagged, masked, or transformed.
+The Polling Collector handles centralized data collection tasks that should only run once per cluster:
+- Scraping Prometheus endpoints
+- Querying the Kubernetes API server for cluster metrics
+- Collecting Kubernetes events
+- Any other polling-based data sources
 
-By capturing and exposing these operational metrics, the Managed Collector empowers you to adopt a data-driven approach to collector management, helping you adapt quickly as your environment, data volume, or compliance requirements evolve.
+This prevents duplicate data collection that would occur if every Agent Collector performed these tasks.
+
+## Remote Management
+
+All collector configuration is managed remotely through the [Cardinal UI](https://app.cardinalhq.io). With the Managed Collector, you can:
+
+- **Add or Remove Sources:** Dynamically introduce new data streams or stop unwanted ones—all without touching the underlying infrastructure.
+- **Manage Destinations:** Seamlessly re-route telemetry data to different backends at any time.
+- **Apply Processing Rules:** Configure transformations, enrichments, or filters with simple configuration changes.
+
+There's no need to redeploy or manually reconfigure collectors—the Managed Collector handles it all remotely and collectors continuously stay up-to-date with the latest configurations.
 
 ## Pipeline Rules
 
-Pipeline rules are flexible, user-defined transformations and filters applied to your telemetry data as it passes through the pipeline. By shaping and refining data before it lands in your storage or monitoring tools, rules help you:
+Pipeline rules are flexible, user-defined transformations and filters applied to your telemetry data as it passes through the pipeline. Rules help you:
 
 - Control costs by removing unnecessary data
-- Enhance data quality and context by adding tags or extracting metrics
+- Enhance data quality by adding tags or extracting metrics
 - Improve privacy by masking or dropping sensitive information
-- Streamline observability efforts, making it easier to investigate and understand system behavior
+- Streamline observability by filtering noise
 
 ### Available Rule Types
 
 | Rule Type | Description |
 |-----------|-------------|
-| **PII Removal/Masking** | Remove or obscure sensitive Personally Identifiable Information from your telemetry |
-| **Extract Metrics** | Convert log fields into metrics on the fly for easier aggregation and alerting |
-| **Custom OTTL** | Write custom conditions and statements using OpenTelemetry Transformation Language |
-| **Filter** | Completely remove certain telemetry items based on defined conditions |
-| **Drop Tags** | Remove high-cardinality tags or dimensions that inflate cost and complexity |
-| **Add Tags** | Enrich telemetry by adding tags (key-value pairs) based on conditions |
-| **Sampling** | Reduce telemetry volume by sampling logs—either randomly or proportionally |
-| **Extract Tags** | Parse unstructured log messages to extract variable parts into structured tags |
+| **PII Removal/Masking** | Remove or obscure sensitive Personally Identifiable Information |
+| **Extract Metrics** | Convert log fields into metrics for aggregation and alerting |
+| **Custom OTTL** | Write custom logic using OpenTelemetry Transformation Language |
+| **Filter** | Remove telemetry items based on defined conditions |
+| **Drop Tags** | Remove high-cardinality tags that inflate cost |
+| **Add Tags** | Enrich telemetry with additional context |
+| **Sampling** | Reduce volume by sampling logs randomly or proportionally |
+| **Extract Tags** | Parse log messages to extract structured tags |
+
+## Observability
+
+The Managed Collector provides granular insights into its own operation:
+
+- **Node Stats:** Track CPU usage, memory consumption, and collector health in real-time
+- **Rule Stats:** Monitor how rules affect your data—how much is filtered, how often tags are extracted, sampling effectiveness
+- **Pipeline Telemetry:** Understand how data moves through sources, rules, and destinations
 
 ## Getting Started
 
@@ -61,6 +85,4 @@ To get started with Managed Collectors:
 1. Navigate to **Collector Pipelines** in the [Cardinal UI](https://app.cardinalhq.io)
 2. Add your desired [Connectors](/managed-collector/connectors) (sources and destinations)
 3. Configure processing rules to shape your telemetry data
-4. Deploy or update your collector using the provided Helm chart
-
-Pipelines are fully managed through the Cardinal UI, and Collectors continuously stay up-to-date with the latest Pipeline configurations.
+4. Deploy collectors using the provided Helm chart


### PR DESCRIPTION
## Summary
- Add Managed Collector as top-level documentation section (peer to Lakerunner and Cardinal Desktop Application)
- Add architecture diagram with light/dark mode support showing Gateway, Agent, and Polling collectors
- Document supported sources and destinations (connectors)

## Test plan
- [ ] Verify docs render correctly on localhost
- [ ] Check diagram displays properly in both light and dark modes
- [ ] Verify all navigation links work