### PR TITLE
Add Lakerunner sizing estimator page

### DIFF
--- a/components/SizingEstimator.module.css
+++ b/components/SizingEstimator.module.css
@@ -1,0 +1,478 @@
+.estimator {
+  margin: 2rem 0;
+}
+
+.privacyNote {
+  text-align: center;
+  font-size: 0.95rem;
+  color: #2e7d32;
+  margin-bottom: 2rem;
+  padding: 1rem 1.5rem;
+  background: rgba(76, 175, 80, 0.1);
+  border-radius: 8px;
+  border: 2px solid rgba(76, 175, 80, 0.3);
+  font-weight: 500;
+}
+
+:global(.dark) .privacyNote {
+  background: rgba(76, 175, 80, 0.15);
+  border-color: rgba(76, 175, 80, 0.4);
+  color: #81c784;
+}
+
+.section {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+:global(.dark) .section {
+  background: rgba(255, 255, 255, 0.02);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.sectionTitle {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+:global(.dark) .sectionTitle {
+  color: #e5e5e5;
+}
+
+.description {
+  margin: 0 0 1.25rem 0;
+  color: #666;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+:global(.dark) .description {
+  color: #999;
+}
+
+/* Time Unit Selector */
+.timeUnitRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.timeUnitLabel {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #444;
+}
+
+:global(.dark) .timeUnitLabel {
+  color: #ccc;
+}
+
+.timeUnitSelect {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  background: white;
+  color: #333;
+  cursor: pointer;
+}
+
+:global(.dark) .timeUnitSelect {
+  background: #0a0a0a;
+  border-color: #444;
+  color: #e5e5e5;
+}
+
+.timeUnitSelect:focus {
+  outline: none;
+  border-color: #ff5722;
+}
+
+/* Input Cards */
+.inputGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .inputGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.inputCard {
+  padding: 1rem;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+:global(.dark) .inputCard {
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+.inputLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+:global(.dark) .inputLabel {
+  color: #e5e5e5;
+}
+
+.inputDot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.inputField {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 1rem;
+  background: white;
+  color: #333;
+  box-sizing: border-box;
+}
+
+:global(.dark) .inputField {
+  background: #0a0a0a;
+  border-color: #444;
+  color: #e5e5e5;
+}
+
+.inputField:focus {
+  outline: none;
+  border-color: #ff5722;
+}
+
+.inputField::-webkit-inner-spin-button,
+.inputField::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.inputField[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.inputHint {
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 0.4rem;
+  display: block;
+}
+
+:global(.dark) .inputHint {
+  color: #777;
+}
+
+/* Query Section */
+.queryRow {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.queryItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.queryLabel {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #444;
+}
+
+:global(.dark) .queryLabel {
+  color: #ccc;
+}
+
+.fixedValue {
+  padding: 0.5rem 0;
+  font-size: 0.9rem;
+  color: #666;
+  font-style: italic;
+}
+
+:global(.dark) .fixedValue {
+  color: #999;
+}
+
+.stepperRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stepperBtn {
+  width: 36px;
+  height: 36px;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  background: white;
+  color: #333;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+:global(.dark) .stepperBtn {
+  background: #1a1a1a;
+  border-color: #444;
+  color: #e5e5e5;
+}
+
+.stepperBtn:hover:not(:disabled) {
+  border-color: #ff5722;
+  color: #ff5722;
+}
+
+.stepperBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.stepperValue {
+  min-width: 2rem;
+  text-align: center;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+:global(.dark) .stepperValue {
+  color: #e5e5e5;
+}
+
+/* Pie Chart */
+.pieContainer {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+@media (max-width: 600px) {
+  .pieContainer {
+    flex-direction: column;
+  }
+}
+
+.pieSvg {
+  width: 200px;
+  height: 200px;
+  flex-shrink: 0;
+  --pie-bg: white;
+}
+
+:global(.dark) .pieSvg {
+  --pie-bg: #111;
+}
+
+.pieCenterBig {
+  font-size: 18px;
+  font-weight: 700;
+  fill: #333;
+}
+
+:global(.dark) .pieCenterBig {
+  fill: #e5e5e5;
+}
+
+.pieCenterSmall {
+  font-size: 10px;
+  fill: #888;
+}
+
+:global(.dark) .pieCenterSmall {
+  fill: #999;
+}
+
+.pieCenter {
+  font-size: 14px;
+  font-weight: 600;
+  fill: #999;
+}
+
+.pieLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.legendDot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.legendLabel {
+  color: #333;
+  font-weight: 500;
+  min-width: 120px;
+}
+
+:global(.dark) .legendLabel {
+  color: #e5e5e5;
+}
+
+.legendValue {
+  color: #666;
+  font-variant-numeric: tabular-nums;
+}
+
+:global(.dark) .legendValue {
+  color: #999;
+}
+
+/* Table */
+.tableWrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table th,
+.table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+  white-space: nowrap;
+}
+
+:global(.dark) .table th,
+:global(.dark) .table td {
+  border-bottom-color: #333;
+}
+
+.table th {
+  font-weight: 600;
+  color: #555;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+:global(.dark) .table th {
+  color: #999;
+}
+
+.table td {
+  color: #333;
+}
+
+:global(.dark) .table td {
+  color: #ddd;
+}
+
+.tableDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+
+.totalRow td {
+  border-top: 2px solid #ff5722;
+  border-bottom: none;
+  padding-top: 0.75rem;
+}
+
+:global(.dark) .totalRow td {
+  border-top-color: #ff5722;
+}
+
+/* Recommendations */
+.recommendations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.recCard {
+  padding: 1rem;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+:global(.dark) .recCard {
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+.recCard h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #333;
+}
+
+:global(.dark) .recCard h4 {
+  color: #e5e5e5;
+}
+
+.recCard p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #555;
+}
+
+:global(.dark) .recCard p {
+  color: #aaa;
+}
+
+/* Empty state */
+.emptyState {
+  text-align: center;
+  padding: 2rem;
+  color: #888;
+  font-style: italic;
+}
+
+:global(.dark) .emptyState {
+  color: #777;
+}

--- a/components/SizingEstimator.tsx
+++ b/components/SizingEstimator.tsx
@@ -1,0 +1,351 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import styles from './SizingEstimator.module.css';
+import {
+  type TimeUnit,
+  type SizingInput,
+  TIME_UNIT_LABELS,
+  calculateSizing,
+  formatMemoryGi,
+  formatCpu,
+} from '../lib/sizingCalculations';
+
+const CATEGORY_COLORS: Record<string, string> = {
+  core: '#607D8B',
+  logs: '#4CAF50',
+  metrics: '#FF9800',
+  traces: '#9C27B0',
+  query: '#2196F3',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  core: 'Core Components',
+  logs: 'Logs',
+  metrics: 'Metrics',
+  traces: 'Traces',
+  query: 'Query',
+};
+
+function PieChart({ data }: { data: Record<string, { cpu: number; memoryMi: number }> }) {
+  const categories = ['core', 'logs', 'metrics', 'traces', 'query'];
+  const values = categories.map(cat => data[cat]?.cpu ?? 0);
+  const total = values.reduce((s, v) => s + v, 0);
+
+  if (total === 0) {
+    return (
+      <div className={styles.pieContainer}>
+        <svg viewBox="0 0 200 200" className={styles.pieSvg}>
+          <circle cx="100" cy="100" r="80" fill="none" stroke="#ccc" strokeWidth="40" />
+          <text x="100" y="100" textAnchor="middle" dominantBaseline="middle" className={styles.pieCenter}>
+            0 vCPU
+          </text>
+        </svg>
+        <div className={styles.pieLegend}>
+          {categories.map(cat => (
+            <div key={cat} className={styles.legendItem}>
+              <span className={styles.legendDot} style={{ background: CATEGORY_COLORS[cat] }} />
+              <span className={styles.legendLabel}>{CATEGORY_LABELS[cat]}</span>
+              <span className={styles.legendValue}>0 vCPU</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Build arcs
+  let cumAngle = -Math.PI / 2; // start at top
+  const arcs: { path: string; color: string; cat: string }[] = [];
+
+  for (let i = 0; i < categories.length; i++) {
+    const fraction = values[i] / total;
+    if (fraction === 0) continue;
+
+    const startAngle = cumAngle;
+    const sweep = fraction * 2 * Math.PI;
+    cumAngle += sweep;
+    const endAngle = cumAngle;
+
+    const cx = 100, cy = 100, r = 80;
+    const x1 = cx + r * Math.cos(startAngle);
+    const y1 = cy + r * Math.sin(startAngle);
+    const x2 = cx + r * Math.cos(endAngle);
+    const y2 = cy + r * Math.sin(endAngle);
+    const largeArc = sweep > Math.PI ? 1 : 0;
+
+    const innerR = 50;
+    // Near-full-circle: split into two half arcs to avoid SVG rendering issues
+    if (fraction > 0.9999) {
+      const midAngle = startAngle + Math.PI;
+      const mx1 = cx + r * Math.cos(midAngle);
+      const my1 = cy + r * Math.sin(midAngle);
+      const imx1 = cx + innerR * Math.cos(midAngle);
+      const imy1 = cy + innerR * Math.sin(midAngle);
+      arcs.push({
+        path: `M ${x1} ${y1} A ${r} ${r} 0 0 1 ${mx1} ${my1} L ${imx1} ${imy1} A ${innerR} ${innerR} 0 0 0 ${cx + innerR * Math.cos(startAngle)} ${cy + innerR * Math.sin(startAngle)} Z`,
+        color: CATEGORY_COLORS[categories[i]],
+        cat: categories[i],
+      });
+      arcs.push({
+        path: `M ${mx1} ${my1} A ${r} ${r} 0 0 1 ${x1} ${y1} L ${cx + innerR * Math.cos(startAngle)} ${cy + innerR * Math.sin(startAngle)} A ${innerR} ${innerR} 0 0 0 ${imx1} ${imy1} Z`,
+        color: CATEGORY_COLORS[categories[i]],
+        cat: categories[i],
+      });
+    } else {
+      const ix1 = cx + innerR * Math.cos(endAngle);
+      const iy1 = cy + innerR * Math.sin(endAngle);
+      const ix2 = cx + innerR * Math.cos(startAngle);
+      const iy2 = cy + innerR * Math.sin(startAngle);
+      arcs.push({
+        path: `M ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} L ${ix1} ${iy1} A ${innerR} ${innerR} 0 ${largeArc} 0 ${ix2} ${iy2} Z`,
+        color: CATEGORY_COLORS[categories[i]],
+        cat: categories[i],
+      });
+    }
+  }
+
+  return (
+    <div className={styles.pieContainer}>
+      <svg viewBox="0 0 200 200" className={styles.pieSvg}>
+        {arcs.map((a, i) => (
+          <path key={i} d={a.path} fill={a.color} />
+        ))}
+        <text x="100" y="95" textAnchor="middle" dominantBaseline="middle" className={styles.pieCenterBig}>
+          {formatCpu(total)}
+        </text>
+        <text x="100" y="112" textAnchor="middle" dominantBaseline="middle" className={styles.pieCenterSmall}>
+          total vCPU
+        </text>
+      </svg>
+      <div className={styles.pieLegend}>
+        {categories.map(cat => {
+          const cpuVal = data[cat]?.cpu ?? 0;
+          if (cpuVal === 0) return null;
+          const pct = total > 0 ? ((cpuVal / total) * 100).toFixed(0) : '0';
+          return (
+            <div key={cat} className={styles.legendItem}>
+              <span className={styles.legendDot} style={{ background: CATEGORY_COLORS[cat] }} />
+              <span className={styles.legendLabel}>{CATEGORY_LABELS[cat]}</span>
+              <span className={styles.legendValue}>{formatCpu(cpuVal)} vCPU ({pct}%)</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function SizingEstimator() {
+  const [timeUnit, setTimeUnit] = useState<TimeUnit>('second');
+  const [logsPerUnit, setLogsPerUnit] = useState<string>('');
+  const [metricsPerUnit, setMetricsPerUnit] = useState<string>('');
+  const [tracesPerUnit, setTracesPerUnit] = useState<string>('');
+  const [queryWorkers, setQueryWorkers] = useState<number>(2);
+
+  const parseNum = (v: string) => {
+    const n = parseFloat(v);
+    return isNaN(n) || n < 0 ? 0 : n;
+  };
+
+  const input: SizingInput = useMemo(() => ({
+    logsPerUnit: parseNum(logsPerUnit),
+    metricsPerUnit: parseNum(metricsPerUnit),
+    tracesPerUnit: parseNum(tracesPerUnit),
+    timeUnit,
+    queryWorkers,
+  }), [logsPerUnit, metricsPerUnit, tracesPerUnit, timeUnit, queryWorkers]);
+
+  const result = useMemo(() => calculateSizing(input), [input]);
+
+  return (
+    <div className={styles.estimator}>
+      <div className={styles.privacyNote}>
+        This calculator runs entirely in your browser. No data is sent to any server.
+      </div>
+
+      {/* Input Section */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Telemetry Throughput</h3>
+        <p className={styles.description}>
+          Enter your expected telemetry volume. Select a time unit that is convenient for you — all values are normalized internally.
+        </p>
+
+        <div className={styles.timeUnitRow}>
+          <label className={styles.timeUnitLabel}>Time unit:</label>
+          <select
+            className={styles.timeUnitSelect}
+            value={timeUnit}
+            onChange={(e) => setTimeUnit(e.target.value as TimeUnit)}
+          >
+            {(Object.keys(TIME_UNIT_LABELS) as TimeUnit[]).map(u => (
+              <option key={u} value={u}>{TIME_UNIT_LABELS[u]}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.inputGrid}>
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>
+              <span className={styles.inputDot} style={{ background: CATEGORY_COLORS.logs }} />
+              Log Lines
+            </label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={logsPerUnit}
+              onChange={(e) => setLogsPerUnit(e.target.value)}
+              placeholder="0"
+              min="0"
+            />
+            <span className={styles.inputHint}>{TIME_UNIT_LABELS[timeUnit]}</span>
+          </div>
+
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>
+              <span className={styles.inputDot} style={{ background: CATEGORY_COLORS.metrics }} />
+              Metric Datapoints
+            </label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={metricsPerUnit}
+              onChange={(e) => setMetricsPerUnit(e.target.value)}
+              placeholder="0"
+              min="0"
+            />
+            <span className={styles.inputHint}>{TIME_UNIT_LABELS[timeUnit]}</span>
+          </div>
+
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>
+              <span className={styles.inputDot} style={{ background: CATEGORY_COLORS.traces }} />
+              Trace Spans
+            </label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={tracesPerUnit}
+              onChange={(e) => setTracesPerUnit(e.target.value)}
+              placeholder="0"
+              min="0"
+            />
+            <span className={styles.inputHint}>{TIME_UNIT_LABELS[timeUnit]}</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Query Section */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Query Capacity</h3>
+        <p className={styles.description}>
+          Query capacity depends on your query patterns, concurrency, and data volume. We recommend a minimum of 2 query-api and 2 query-worker pods.
+        </p>
+        <div className={styles.queryRow}>
+          <div className={styles.queryItem}>
+            <label className={styles.queryLabel}>Query API Pods</label>
+            <div className={styles.fixedValue}>2 (minimum)</div>
+          </div>
+          <div className={styles.queryItem}>
+            <label className={styles.queryLabel}>Query Workers</label>
+            <div className={styles.stepperRow}>
+              <button
+                className={styles.stepperBtn}
+                onClick={() => setQueryWorkers(Math.max(2, queryWorkers - 1))}
+                disabled={queryWorkers <= 2}
+              >
+                -
+              </button>
+              <span className={styles.stepperValue}>{queryWorkers}</span>
+              <button
+                className={styles.stepperBtn}
+                onClick={() => setQueryWorkers(queryWorkers + 1)}
+              >
+                +
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Results */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Estimated Resources</h3>
+
+        <PieChart data={result.categoryTotals} />
+
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Category</th>
+                <th>Pods</th>
+                <th>Total vCPU</th>
+                <th>Total Memory</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(['core', 'logs', 'metrics', 'traces', 'query'] as const).map(cat => {
+                const catComponents = result.components.filter(c => c.category === cat);
+                const pods = catComponents.reduce((s, c) => s + c.pods, 0);
+                const cpu = result.categoryTotals[cat]?.cpu ?? 0;
+                const mem = result.categoryTotals[cat]?.memoryMi ?? 0;
+                if (pods === 0 && cat !== 'core' && cat !== 'query') return null;
+                return (
+                  <tr key={cat}>
+                    <td>
+                      <span className={styles.tableDot} style={{ background: CATEGORY_COLORS[cat] }} />
+                      {CATEGORY_LABELS[cat]}
+                    </td>
+                    <td>{pods}</td>
+                    <td>{formatCpu(cpu)} vCPU</td>
+                    <td>{formatMemoryGi(mem)} Gi</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className={styles.totalRow}>
+                <td><strong>Grand Total</strong></td>
+                <td><strong>{result.components.reduce((s, c) => s + c.pods, 0)}</strong></td>
+                <td><strong>{formatCpu(result.grandTotalCpu)} vCPU</strong></td>
+                <td><strong>{formatMemoryGi(result.grandTotalMemoryMi)} Gi</strong></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </section>
+
+      {/* Recommendations */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Recommendations</h3>
+        <div className={styles.recommendations}>
+          <div className={styles.recCard}>
+            <h4>Auto-Scaling</h4>
+            <p>
+              Log, metric, trace, and query components <strong>auto-scale based on demand</strong> using KEDA.
+              The estimates above represent a <strong>maximum footprint</strong> at sustained peak load.
+              Actual resource usage will be lower during normal operation.
+            </p>
+          </div>
+          <div className={styles.recCard}>
+            <h4>Cluster Auto-Scaling</h4>
+            <p>
+              We strongly recommend enabling <strong>Kubernetes cluster auto-scaling</strong> to automatically
+              add and remove nodes as workload pods scale up and down. This ensures you only pay for
+              the compute capacity you actually need.
+            </p>
+          </div>
+          <div className={styles.recCard}>
+            <h4>Spot / Preemptible Instances</h4>
+            <p>
+              Lakerunner workloads are well-suited for <strong>Spot Instances</strong> (AWS) or <strong>Preemptible VMs</strong> (GCP).
+              These can reduce compute costs by 60-90%. All Lakerunner components are designed to handle
+              interruptions gracefully through work queue-based processing.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/docs/plans/lakerunner-sizing-estimator.md
+++ b/docs/plans/lakerunner-sizing-estimator.md
@@ -1,0 +1,59 @@
+# Lakerunner Sizing Estimator — Implementation Plan
+
+## Overview
+
+Build an interactive sizing estimator page for the Lakerunner docs site. The page will have a React component that accepts user throughput inputs, calculates pod counts and resource requirements, and renders a summary table + SVG pie chart.
+
+## File Changes
+
+### Create
+1. `components/SizingEstimator.tsx` — Main React component
+2. `components/SizingEstimator.module.css` — CSS module (follows existing pattern)
+3. `lib/sizingCalculations.ts` — Pure calculation functions (normalization, pod counts, resource totals)
+4. `pages/lakerunner/sizing.mdx` — MDX page that imports the component
+
+### Modify
+1. `pages/lakerunner/_meta.json` — Add "sizing" nav entry
+
+## Implementation Steps
+
+### Step 1: Create calculation utilities (`lib/sizingCalculations.ts`)
+- Time unit conversion: normalize any input to per-second
+- Pod count formulas for each component type
+- Resource aggregation by category (core, logs, metrics, traces, query)
+- Type definitions for inputs and outputs
+
+### Step 2: Create the SizingEstimator component (`components/SizingEstimator.tsx`)
+- **Input section**: Time unit selector (dropdown), throughput fields for logs/metrics/traces, query worker count stepper
+- **Results section**: Summary table with component breakdown, grand totals
+- **Pie chart**: Simple SVG donut/pie chart showing vCPU distribution across 5 categories
+- **Recommendations callout**: Auto-scaling note, cluster auto-scaling, spot/preemptible instance guidance
+- All state managed with useState hooks
+- Follow existing component patterns (CSS modules, dark mode support)
+
+### Step 3: Create CSS module (`components/SizingEstimator.module.css`)
+- Reuse visual patterns from `LakerunnerHelmValuesWizard.module.css`
+- Section cards, form controls, tables, pie chart container
+- Dark mode via `:global(.dark)` selectors
+- Responsive grid for mobile
+
+### Step 4: Create the MDX page (`pages/lakerunner/sizing.mdx`)
+- Import SizingEstimator component
+- Brief introductory text
+- Render the component
+- Import SupportCallout at bottom
+
+### Step 5: Update navigation (`pages/lakerunner/_meta.json`)
+- Add `"sizing": "Sizing Estimator"` entry
+
+## Testing Strategy
+- Manual verification in dev server (all time units, zero inputs, large inputs)
+- Visual verification of pie chart rendering
+- Dark mode toggle check
+- `pnpm build` success
+
+## Risks / Considerations
+- SVG pie chart needs to handle edge case where all categories are 0 (show empty state)
+- Pie chart needs to handle single-category case (full circle, not a zero-width arc)
+- Memory values mix Mi and Gi — normalize everything to Mi internally, display as Gi
+- No external charting dependency — pure SVG with calculated arc paths

--- a/docs/specs/lakerunner-sizing-estimator.md
+++ b/docs/specs/lakerunner-sizing-estimator.md
@@ -1,0 +1,100 @@
+# Lakerunner Sizing Estimator — Specification
+
+## Goal
+
+Build an interactive sizing estimation page for Lakerunner that helps users estimate the vCPU and memory footprint of their deployment based on expected telemetry throughput. The calculator runs entirely in the browser (no server calls) and produces a visual breakdown of resource requirements across five component categories.
+
+## Requirements
+
+### Functional
+
+1. **Input: Telemetry Throughput**
+   - User selects a time unit: per second, per minute, per hour, per day, or per month
+   - User enters volume for each enabled signal type:
+     - Logs: lines per [time unit]
+     - Metrics: datapoints per [time unit]
+     - Traces: spans per [time unit]
+   - All values are normalized to per-second internally for pod calculation
+   - Conversion factors: second=1, minute=60, hour=3600, day=86400, month=2592000 (30-day month)
+   - Accept non-negative numeric values only; empty/invalid input treated as 0
+
+2. **Input: Query Workers**
+   - Minimum 2 query-api pods (fixed, not user-configurable below 2)
+   - Minimum 2 query-worker pods (user can increase, minimum 2)
+   - UI allows user to choose additional query workers beyond the minimum
+
+3. **Pod Calculation Logic** (per-second throughput basis)
+   - **Log ingest pods**: ceil(logs_per_sec / 40,000)
+   - **Trace ingest pods**: ceil(traces_per_sec / 40,000)
+   - **Metric ingest pods**: ceil(metrics_per_sec / 20,000)
+   - **Log compact pods**: ceil(log_ingest_pods * 0.5)
+   - **Trace compact pods**: ceil(trace_ingest_pods * 0.5)
+   - **Metric compact pods**: ceil(metric_ingest_pods * 1.5)
+   - **Metric rollup pods**: metric_ingest_pods (1:1 match)
+   - **Query API pods**: 2 (fixed minimum)
+   - **Query Worker pods**: 2 minimum, user-selectable higher
+   - If throughput for a signal is 0, related ingest/compact/rollup pods are 0
+
+4. **Resource Sizing per Pod** (from Helm values.yaml defaults)
+   - Core components (always present):
+     - setup: 1.1 vCPU, 250Mi memory (run-once job, excluded from steady-state)
+     - sweeper: 0.25 vCPU, 300Mi memory
+     - monitoring: 0.25 vCPU, 100Mi memory
+     - admin-api: 0.25 vCPU, 200Mi memory
+     - boxer (common): 0.2 vCPU, 250Mi memory
+   - Log pipeline per pod: 1 vCPU, 4Gi memory (ingest and compact)
+   - Metric ingest per pod: 1 vCPU, 4Gi memory
+   - Metric compact per pod: 1 vCPU, 5Gi memory
+   - Metric rollup per pod: 4 vCPU, 8Gi memory
+   - Trace pipeline per pod: 1 vCPU, 4Gi memory (ingest and compact)
+   - Query API per pod: 1 vCPU, 4Gi memory
+   - Query Worker per pod: 2 vCPU, 4Gi memory
+
+5. **Output: Resource Summary**
+   - Table showing each component, pod count, per-pod resources, and total resources
+   - Grand total vCPU and memory
+   - Simple pie chart showing resource distribution across 5 categories:
+     - Core Components (sweeper + monitoring + admin-api + boxer)
+     - Logs (ingest + compact)
+     - Metrics (ingest + compact + rollup)
+     - Traces (ingest + compact)
+     - Query (query-api + query-workers)
+
+6. **Recommendations Callout**
+   - Note that log, metric, trace, and query components auto-scale based on demand — this estimate represents a maximum
+   - Recommend cluster auto-scaling to remove unneeded k8s nodes as load changes
+   - Recommend Spot instances (AWS) / Preemptible VMs (GCP) for this workload to reduce cost
+
+### Non-Functional
+- Runs entirely client-side in the browser — no data sent to any server
+- Follows existing Nextra + CSS module patterns used in the codebase
+- Supports dark mode (matches existing `:global(.dark)` pattern)
+- Responsive layout for mobile
+
+## Scope
+
+### In Scope
+- New MDX page at `pages/lakerunner/sizing.mdx`
+- New React component `components/SizingEstimator.tsx` with CSS module
+- SVG-based pie chart (no external charting library dependency)
+- Navigation entry in `pages/lakerunner/_meta.json`
+
+### Out of Scope
+- Cost estimation (no dollar amounts)
+- Persistent storage / saving configurations
+- PubSub pod sizing (notification delivery is deployment-specific)
+- Grafana pod sizing (optional component)
+- Collector pod sizing (managed separately)
+
+## Acceptance Criteria
+- [ ] Page accessible at `/lakerunner/sizing` in the nav
+- [ ] User can select time unit and enter throughput for logs, metrics, traces
+- [ ] Pod counts and resource totals calculate correctly per the formulas above
+- [ ] Pie chart renders showing the 5 category breakdown (by vCPU)
+- [ ] Recommendations section displays auto-scaling, cluster auto-scaling, and spot instance guidance
+- [ ] Dark mode works correctly
+- [ ] Responsive on mobile
+- [ ] `pnpm build` succeeds without errors
+
+## Open Questions
+- None at this time — all requirements provided by user

--- a/lib/sizingCalculations.ts
+++ b/lib/sizingCalculations.ts
@@ -1,0 +1,152 @@
+export type TimeUnit = 'second' | 'minute' | 'hour' | 'day' | 'month';
+
+export const TIME_UNIT_LABELS: Record<TimeUnit, string> = {
+  second: 'per second',
+  minute: 'per minute',
+  hour: 'per hour',
+  day: 'per day',
+  month: 'per month',
+};
+
+const TIME_UNIT_DIVISORS: Record<TimeUnit, number> = {
+  second: 1,
+  minute: 60,
+  hour: 3_600,
+  day: 86_400,
+  month: 2_592_000, // 30-day month
+};
+
+// Throughput capacity per pod (events per second)
+const LOG_INGEST_CAPACITY = 40_000;
+const TRACE_INGEST_CAPACITY = 40_000;
+const METRIC_INGEST_CAPACITY = 20_000;
+
+// Resource sizing per pod (from Helm values.yaml defaults)
+export interface PodResources {
+  cpu: number;    // vCPU
+  memoryMi: number; // MiB
+}
+
+export const RESOURCE_DEFAULTS: Record<string, PodResources> = {
+  // Core components
+  sweeper:    { cpu: 0.25, memoryMi: 300 },
+  monitoring: { cpu: 0.25, memoryMi: 100 },
+  adminApi:   { cpu: 0.25, memoryMi: 200 },
+  boxer:      { cpu: 0.2,  memoryMi: 250 },
+  // Log pipeline
+  ingestLogs:  { cpu: 1, memoryMi: 4096 },
+  compactLogs: { cpu: 1, memoryMi: 4096 },
+  // Metric pipeline
+  ingestMetrics:  { cpu: 1, memoryMi: 4096 },
+  compactMetrics: { cpu: 1, memoryMi: 5120 },
+  rollupMetrics:  { cpu: 4, memoryMi: 8192 },
+  // Trace pipeline
+  ingestTraces:  { cpu: 1, memoryMi: 4096 },
+  compactTraces: { cpu: 1, memoryMi: 4096 },
+  // Query
+  queryApi:    { cpu: 1, memoryMi: 4096 },
+  queryWorker: { cpu: 2, memoryMi: 4096 },
+};
+
+export interface SizingInput {
+  logsPerUnit: number;
+  metricsPerUnit: number;
+  tracesPerUnit: number;
+  timeUnit: TimeUnit;
+  queryWorkers: number;
+}
+
+export interface ComponentEstimate {
+  name: string;
+  category: 'core' | 'logs' | 'metrics' | 'traces' | 'query';
+  pods: number;
+  cpuPerPod: number;
+  memoryMiPerPod: number;
+  totalCpu: number;
+  totalMemoryMi: number;
+}
+
+export interface SizingResult {
+  components: ComponentEstimate[];
+  categoryTotals: Record<string, { cpu: number; memoryMi: number }>;
+  grandTotalCpu: number;
+  grandTotalMemoryMi: number;
+}
+
+export function normalizeToPerSecond(value: number, unit: TimeUnit): number {
+  const divisor = TIME_UNIT_DIVISORS[unit];
+  return value / divisor;
+}
+
+export function calculateSizing(input: SizingInput): SizingResult {
+  const logsPerSec = normalizeToPerSecond(Math.max(0, input.logsPerUnit), input.timeUnit);
+  const metricsPerSec = normalizeToPerSecond(Math.max(0, input.metricsPerUnit), input.timeUnit);
+  const tracesPerSec = normalizeToPerSecond(Math.max(0, input.tracesPerUnit), input.timeUnit);
+  const queryWorkers = Math.max(2, Math.round(input.queryWorkers));
+
+  // Pod counts
+  // Logs and metrics always have a minimum of 1 ingest pod (needed to monitor Lakerunner itself)
+  const logIngestPods = Math.max(1, Math.ceil(logsPerSec / LOG_INGEST_CAPACITY));
+  const logCompactPods = Math.max(1, Math.ceil(logIngestPods * 0.5));
+
+  const metricIngestPods = Math.max(1, Math.ceil(metricsPerSec / METRIC_INGEST_CAPACITY));
+  const metricCompactPods = Math.max(1, Math.ceil(metricIngestPods * 1.5));
+  const metricRollupPods = metricIngestPods; // 1:1 match
+
+  // Traces can scale to 0
+  const traceIngestPods = tracesPerSec > 0 ? Math.ceil(tracesPerSec / TRACE_INGEST_CAPACITY) : 0;
+  const traceCompactPods = traceIngestPods > 0 ? Math.max(1, Math.ceil(traceIngestPods * 0.5)) : 0;
+
+  const r = RESOURCE_DEFAULTS;
+
+  const components: ComponentEstimate[] = [
+    // Core (always present)
+    { name: 'Sweeper', category: 'core', pods: 1, cpuPerPod: r.sweeper.cpu, memoryMiPerPod: r.sweeper.memoryMi, totalCpu: r.sweeper.cpu, totalMemoryMi: r.sweeper.memoryMi },
+    { name: 'Monitoring', category: 'core', pods: 1, cpuPerPod: r.monitoring.cpu, memoryMiPerPod: r.monitoring.memoryMi, totalCpu: r.monitoring.cpu, totalMemoryMi: r.monitoring.memoryMi },
+    { name: 'Admin API', category: 'core', pods: 1, cpuPerPod: r.adminApi.cpu, memoryMiPerPod: r.adminApi.memoryMi, totalCpu: r.adminApi.cpu, totalMemoryMi: r.adminApi.memoryMi },
+    { name: 'Boxer', category: 'core', pods: 1, cpuPerPod: r.boxer.cpu, memoryMiPerPod: r.boxer.memoryMi, totalCpu: r.boxer.cpu, totalMemoryMi: r.boxer.memoryMi },
+    // Logs
+    ...(logIngestPods > 0 ? [
+      { name: 'Log Ingest', category: 'logs' as const, pods: logIngestPods, cpuPerPod: r.ingestLogs.cpu, memoryMiPerPod: r.ingestLogs.memoryMi, totalCpu: logIngestPods * r.ingestLogs.cpu, totalMemoryMi: logIngestPods * r.ingestLogs.memoryMi },
+      { name: 'Log Compact', category: 'logs' as const, pods: logCompactPods, cpuPerPod: r.compactLogs.cpu, memoryMiPerPod: r.compactLogs.memoryMi, totalCpu: logCompactPods * r.compactLogs.cpu, totalMemoryMi: logCompactPods * r.compactLogs.memoryMi },
+    ] : []),
+    // Metrics
+    ...(metricIngestPods > 0 ? [
+      { name: 'Metric Ingest', category: 'metrics' as const, pods: metricIngestPods, cpuPerPod: r.ingestMetrics.cpu, memoryMiPerPod: r.ingestMetrics.memoryMi, totalCpu: metricIngestPods * r.ingestMetrics.cpu, totalMemoryMi: metricIngestPods * r.ingestMetrics.memoryMi },
+      { name: 'Metric Compact', category: 'metrics' as const, pods: metricCompactPods, cpuPerPod: r.compactMetrics.cpu, memoryMiPerPod: r.compactMetrics.memoryMi, totalCpu: metricCompactPods * r.compactMetrics.cpu, totalMemoryMi: metricCompactPods * r.compactMetrics.memoryMi },
+      { name: 'Metric Rollup', category: 'metrics' as const, pods: metricRollupPods, cpuPerPod: r.rollupMetrics.cpu, memoryMiPerPod: r.rollupMetrics.memoryMi, totalCpu: metricRollupPods * r.rollupMetrics.cpu, totalMemoryMi: metricRollupPods * r.rollupMetrics.memoryMi },
+    ] : []),
+    // Traces
+    ...(traceIngestPods > 0 ? [
+      { name: 'Trace Ingest', category: 'traces' as const, pods: traceIngestPods, cpuPerPod: r.ingestTraces.cpu, memoryMiPerPod: r.ingestTraces.memoryMi, totalCpu: traceIngestPods * r.ingestTraces.cpu, totalMemoryMi: traceIngestPods * r.ingestTraces.memoryMi },
+      { name: 'Trace Compact', category: 'traces' as const, pods: traceCompactPods, cpuPerPod: r.compactTraces.cpu, memoryMiPerPod: r.compactTraces.memoryMi, totalCpu: traceCompactPods * r.compactTraces.cpu, totalMemoryMi: traceCompactPods * r.compactTraces.memoryMi },
+    ] : []),
+    // Query (always present)
+    { name: 'Query API', category: 'query', pods: 2, cpuPerPod: r.queryApi.cpu, memoryMiPerPod: r.queryApi.memoryMi, totalCpu: 2 * r.queryApi.cpu, totalMemoryMi: 2 * r.queryApi.memoryMi },
+    { name: 'Query Worker', category: 'query', pods: queryWorkers, cpuPerPod: r.queryWorker.cpu, memoryMiPerPod: r.queryWorker.memoryMi, totalCpu: queryWorkers * r.queryWorker.cpu, totalMemoryMi: queryWorkers * r.queryWorker.memoryMi },
+  ];
+
+  // Category totals
+  const categories = ['core', 'logs', 'metrics', 'traces', 'query'] as const;
+  const categoryTotals: Record<string, { cpu: number; memoryMi: number }> = {};
+  for (const cat of categories) {
+    const catComponents = components.filter(c => c.category === cat);
+    categoryTotals[cat] = {
+      cpu: catComponents.reduce((sum, c) => sum + c.totalCpu, 0),
+      memoryMi: catComponents.reduce((sum, c) => sum + c.totalMemoryMi, 0),
+    };
+  }
+
+  const grandTotalCpu = components.reduce((sum, c) => sum + c.totalCpu, 0);
+  const grandTotalMemoryMi = components.reduce((sum, c) => sum + c.totalMemoryMi, 0);
+
+  return { components, categoryTotals, grandTotalCpu, grandTotalMemoryMi };
+}
+
+export function formatMemoryGi(mi: number): string {
+  return (mi / 1024).toFixed(2);
+}
+
+export function formatCpu(cpu: number): string {
+  return cpu.toFixed(2);
+}

--- a/pages/lakerunner/_meta.json
+++ b/pages/lakerunner/_meta.json
@@ -1,6 +1,7 @@
 {
   "index": "Overview",
   "install": "Installation Guide",
+  "sizing": "Sizing Estimator",
   "architecture": "Architecture",
   "cli": "CLI Reference",
   "query-language": "Query Language",

--- a/pages/lakerunner/sizing.mdx
+++ b/pages/lakerunner/sizing.mdx
@@ -1,0 +1,10 @@
+import SizingEstimator from '../../components/SizingEstimator';
+import SupportCallout from '../../components/SupportCallout';
+
+# Sizing Estimator
+
+Use this calculator to estimate the compute resources (vCPU and memory) required for your Lakerunner deployment based on your expected telemetry throughput.
+
+<SizingEstimator />
+
+<SupportCallout />


### PR DESCRIPTION
## Summary
- Adds interactive sizing estimator at `/lakerunner/sizing` that calculates vCPU and memory footprint based on expected telemetry throughput
- Users select a time unit (second/minute/hour/day/month) and enter log, metric, and trace volumes
- Pod counts calculated per spec: logs 40k/s, traces 40k/s, metrics 20k/s per pod; compaction at 50% for logs/traces, 150% for metrics; rollups match metric ingest count
- Logs and metrics enforce minimum 1 ingest pod (required for Lakerunner self-monitoring); traces can scale to 0
- SVG donut pie chart shows vCPU distribution across 5 categories (core, logs, metrics, traces, query)
- Grouped summary table (not per-pod detail) with category totals
- Recommendations section covering KEDA auto-scaling, cluster auto-scaling, and Spot/Preemptible instances

## Test plan
- [ ] Navigate to `/lakerunner/sizing` and verify page loads with baseline resources (core + logs + metrics + query)
- [ ] Enter throughput values and confirm pod counts match formulas
- [ ] Verify traces row and legend entry hidden when trace input is 0
- [ ] Switch time units and confirm calculations update correctly
- [ ] Test query worker stepper (min 2, increment/decrement)
- [ ] Verify dark mode rendering
- [ ] Verify responsive layout on mobile viewport
- [ ] Run `pnpm build` to confirm no build errors