### PR TITLE
Update helm wizard to match chart v3.3.1

### DIFF
--- a/components/LakerunnerHelmValuesWizard.module.css
+++ b/components/LakerunnerHelmValuesWizard.module.css
@@ -369,6 +369,65 @@
   color: #ffc107;
 }
 
+/* Scaling Table */
+.scalingTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.scalingTable th,
+.scalingTable td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+:global(.dark) .scalingTable th,
+:global(.dark) .scalingTable td {
+  border-bottom-color: #333;
+}
+
+.scalingTable th {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #666;
+}
+
+:global(.dark) .scalingTable th {
+  color: #999;
+}
+
+.scalingTable td {
+  font-size: 0.9rem;
+  color: #333;
+}
+
+:global(.dark) .scalingTable td {
+  color: #e5e5e5;
+}
+
+.scalingTable td input {
+  width: 80px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  background: white;
+  color: #333;
+  text-align: center;
+}
+
+:global(.dark) .scalingTable td input {
+  background: #0a0a0a;
+  border-color: #444;
+  color: #e5e5e5;
+}
+
+.scalingTable td input:focus {
+  outline: none;
+  border-color: #ff5722;
+}
+
 /* Output Section */
 .outputHeader {
   display: flex;

--- a/components/LakerunnerHelmValuesWizard.tsx
+++ b/components/LakerunnerHelmValuesWizard.tsx
@@ -8,6 +8,7 @@ import {
   isValidCollectorName,
   isValidUUID,
   isValidPort,
+  isValidLicenseData,
   createDefaultState,
   generateValuesYaml,
 } from '../lib/generateValuesYaml';
@@ -66,6 +67,9 @@ export default function LakerunnerHelmValuesWizard() {
       // POC: Grafana enabled by default
       // Production: Grafana disabled by default
       enableGrafana: installType === 'poc',
+      scaling: installType === 'production'
+        ? { processLogsMax: '10', processMetricsMax: '10', processTracesMax: '10' }
+        : { processLogsMax: '10', processMetricsMax: '10', processTracesMax: '10' },
     }));
   };
 
@@ -190,63 +194,7 @@ export default function LakerunnerHelmValuesWizard() {
               <span className={styles.hint}>Pre-configured Grafana with Lakerunner datasources</span>
             </div>
 
-            {/* Cardinal Monitoring Component */}
-            <div className={styles.optionalComponent}>
-              <label className={styles.checkboxLabel}>
-                <input
-                  type="checkbox"
-                  checked={state.enableCardinalMonitoring}
-                  onChange={(e) => updateState('enableCardinalMonitoring', e.target.checked)}
-                />
-                <strong>Monitoring by Cardinal</strong>
-              </label>
-              <span className={styles.hint}>Send Lakerunner telemetry to Cardinal for monitoring. Cardinal will monitor your Lakerunner deployment and provide a dashboard for performance monitoring. We will not see your organization's data, just Lakerunner performance.</span>
-              {state.enableCardinalMonitoring && (
-                <div className={styles.componentSettings}>
-                  <div className={styles.formGroup}>
-                    <label>Cardinal Cloud API Key <span className={styles.required}>*</span></label>
-                    <input
-                      type="text"
-                      value={state.cardinalApiKey}
-                      onChange={(e) => updateState('cardinalApiKey', e.target.value)}
-                      placeholder="your-cardinal-cloud-api-key"
-                      className={!state.cardinalApiKey.trim() ? styles.inputError : ''}
-                    />
-                    <span className={styles.hint}>
-                      This is different from the Lakerunner API key above. Sign up at <a href="https://app.cardinalhq.io" target="_blank" rel="noopener noreferrer">app.cardinalhq.io</a> and copy your API key from the dashboard.
-                    </span>
-                  </div>
-                </div>
-              )}
-              {!state.enableCardinalMonitoring && (
-                <div className={styles.componentSettings}>
-                  <div className={styles.warningBox}>
-                    <strong>⚠️ Warning:</strong> Without Cardinal monitoring, ensure your Lakerunner deployment is properly monitored by another observability solution.
-                  </div>
-                </div>
-              )}
-            </div>
 
-            {/* KEDA Component */}
-            <div className={styles.optionalComponent}>
-              <label className={styles.checkboxLabel}>
-                <input
-                  type="checkbox"
-                  checked={state.enableKeda}
-                  onChange={(e) => updateState('enableKeda', e.target.checked)}
-                />
-                <strong>KEDA Autoscaling</strong>
-              </label>
-              <span className={styles.hint}>Work queue-based autoscaling for production workloads</span>
-              {!state.enableKeda && (state.installType === 'poc' || state.installType === 'production') && (
-                <div className={styles.componentSettings}>
-                  <div className={styles.warningBox}>
-                    <strong>⚠️ Warning:</strong> KEDA is highly recommended for {state.installType === 'poc' ? 'POC' : 'production'} deployments.
-                    It provides intelligent scaling based on workload backlog, which is essential for micro-batch workloads.
-                  </div>
-                </div>
-              )}
-            </div>
           </section>
 
           {/* Cloud Provider */}
@@ -692,95 +640,237 @@ export default function LakerunnerHelmValuesWizard() {
             </div>
           </section>
 
-          {/* Kafka Configuration */}
+          {/* License Configuration */}
           <section className={styles.section}>
-            <h3 className={styles.sectionTitle}>Kafka</h3>
+            <h3 className={styles.sectionTitle}>License</h3>
+            <p className={styles.hint}>
+              A valid license is required for Lakerunner to operate. Contact <a href="mailto:support@cardinalhq.com">support@cardinalhq.com</a> to obtain one.
+            </p>
             <div className={styles.formGrid}>
               <div className={`${styles.formGroup} ${styles.fullWidth}`}>
-                <label>Credentials</label>
+                <label>License Source</label>
                 <div className={styles.credentialModeSelect}>
                   <button
-                    className={`${styles.credentialModeBtn} ${state.kafka.credentialMode === 'create' ? styles.active : ''}`}
-                    onClick={() => updateNested('kafka', 'credentialMode', 'create')}
+                    className={`${styles.credentialModeBtn} ${state.license.mode === 'create' ? styles.active : ''}`}
+                    onClick={() => updateNested('license', 'mode', 'create')}
                   >
-                    Create Secret
+                    Provide License Data
                   </button>
                   <button
-                    className={`${styles.credentialModeBtn} ${state.kafka.credentialMode === 'existing' ? styles.active : ''}`}
-                    onClick={() => updateNested('kafka', 'credentialMode', 'existing')}
+                    className={`${styles.credentialModeBtn} ${state.license.mode === 'existing' ? styles.active : ''}`}
+                    onClick={() => updateNested('license', 'mode', 'existing')}
                   >
                     Use Existing Secret
                   </button>
                 </div>
               </div>
-              <div className={`${styles.formGroup} ${styles.fullWidth}`}>
-                <label>Broker Addresses <span className={styles.required}>*</span></label>
+              <div className={styles.formGroup}>
+                <label>Secret Name</label>
                 <input
                   type="text"
-                  value={state.kafka.brokers}
-                  onChange={(e) => updateNested('kafka', 'brokers', e.target.value)}
-                  placeholder="kafka-1:9092,kafka-2:9092,kafka-3:9092"
-                  className={!state.kafka.brokers.trim() ? styles.inputError : ''}
+                  value={state.license.secretName}
+                  onChange={(e) => updateNested('license', 'secretName', e.target.value)}
+                  placeholder="lakerunner-license"
                 />
               </div>
-              <div className={styles.formGroup}>
-                <label>SASL Mechanism</label>
-                <select
-                  value={state.kafka.saslMechanism}
-                  onChange={(e) => updateNested('kafka', 'saslMechanism', e.target.value)}
-                >
-                  <option value="PLAIN">PLAIN</option>
-                  <option value="SCRAM-SHA-256">SCRAM-SHA-256</option>
-                  <option value="SCRAM-SHA-512">SCRAM-SHA-512</option>
-                </select>
-              </div>
-              {state.kafka.credentialMode === 'create' ? (
-                <>
-                  <div className={styles.formGroup}>
-                    <label>Username <span className={styles.required}>*</span></label>
-                    <input
-                      type="text"
-                      value={state.kafka.username}
-                      onChange={(e) => updateNested('kafka', 'username', e.target.value)}
-                      placeholder="kafka-user"
-                      className={!state.kafka.username.trim() ? styles.inputError : ''}
-                    />
-                  </div>
-                  <div className={styles.formGroup}>
-                    <label>Password <span className={styles.required}>*</span></label>
-                    <input
-                      type="password"
-                      value={state.kafka.password}
-                      onChange={(e) => updateNested('kafka', 'password', e.target.value)}
-                      placeholder="••••••••"
-                      className={!state.kafka.password.trim() ? styles.inputError : ''}
-                    />
-                  </div>
-                </>
-              ) : (
-                <div className={styles.formGroup}>
-                  <label>Secret Name <span className={styles.required}>*</span></label>
+              {state.license.mode === 'create' ? (
+                <div className={`${styles.formGroup} ${styles.fullWidth}`}>
+                  <label>License Data <span className={styles.required}>*</span></label>
                   <input
                     type="text"
-                    value={state.kafka.existingSecretName}
-                    onChange={(e) => updateNested('kafka', 'existingSecretName', e.target.value)}
-                    placeholder="kafka-credentials"
-                    className={!state.kafka.existingSecretName.trim() ? styles.inputError : ''}
+                    value={state.license.data}
+                    onChange={(e) => updateNested('license', 'data', e.target.value)}
+                    placeholder='b64:... or z64:...'
+                    className={state.license.data.trim() && !isValidLicenseData(state.license.data) ? styles.inputError : ''}
                   />
-                  <span className={styles.hint}>Name of existing Kubernetes secret containing credentials (keys: KAFKA_USERNAME, KAFKA_PASSWORD)</span>
+                  {state.license.data.trim() && !isValidLicenseData(state.license.data) && (
+                    <span className={styles.errorText}>
+                      License must start with "b64:" or "z64:"
+                    </span>
+                  )}
+                  <span className={styles.hint}>Paste your license string (starts with b64: or z64:)</span>
+                </div>
+              ) : (
+                <div className={`${styles.formGroup} ${styles.fullWidth}`}>
+                  <span className={styles.hint}>
+                    The secret must contain your license data under the key "license.json".
+                  </span>
                 </div>
               )}
-              <div className={styles.formGroup}>
-                <label className={styles.checkboxLabel}>
-                  <input
-                    type="checkbox"
-                    checked={state.kafka.useTls}
-                    onChange={(e) => updateNested('kafka', 'useTls', e.target.checked)}
-                  />
-                  Use TLS
-                </label>
-              </div>
             </div>
+          </section>
+
+          {/* Scaling Configuration */}
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Scaling</h3>
+            <p className={styles.hint}>
+              Lakerunner uses internal autoscaling from 1 pod up to the max you set here.
+            </p>
+            <table className={styles.scalingTable}>
+              <thead>
+                <tr>
+                  <th>Service</th>
+                  <th>Max Pods</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Log Processing</td>
+                  <td>
+                    <input
+                      type="text"
+                      value={state.scaling.processLogsMax}
+                      onChange={(e) => updateNested('scaling', 'processLogsMax', e.target.value)}
+                      placeholder="10"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Metric Processing</td>
+                  <td>
+                    <input
+                      type="text"
+                      value={state.scaling.processMetricsMax}
+                      onChange={(e) => updateNested('scaling', 'processMetricsMax', e.target.value)}
+                      placeholder="10"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Trace Processing</td>
+                  <td>
+                    <input
+                      type="text"
+                      value={state.scaling.processTracesMax}
+                      onChange={(e) => updateNested('scaling', 'processTracesMax', e.target.value)}
+                      placeholder="10"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          {/* PubSub Configuration */}
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Ingestion</h3>
+            {state.cloudProvider === 'gcp' ? (
+              <>
+                <p className={styles.hint}>
+                  GCP uses Pub/Sub for ingestion from Cloud Storage notifications.
+                </p>
+                <div className={styles.formGrid}>
+                  <div className={styles.formGroup}>
+                    <label>GCP Project ID <span className={styles.required}>*</span></label>
+                    <input
+                      type="text"
+                      value={state.pubsub.gcpProjectID}
+                      onChange={(e) => updateNested('pubsub', 'gcpProjectID', e.target.value)}
+                      placeholder="my-project-123456"
+                      className={!state.pubsub.gcpProjectID.trim() ? styles.inputError : ''}
+                    />
+                  </div>
+                  <div className={styles.formGroup}>
+                    <label>Subscription ID <span className={styles.required}>*</span></label>
+                    <input
+                      type="text"
+                      value={state.pubsub.gcpSubscriptionID}
+                      onChange={(e) => updateNested('pubsub', 'gcpSubscriptionID', e.target.value)}
+                      placeholder="my-subscription"
+                      className={!state.pubsub.gcpSubscriptionID.trim() ? styles.inputError : ''}
+                    />
+                  </div>
+                  <div className={styles.formGroup}>
+                    <label>Replicas</label>
+                    <input
+                      type="text"
+                      value={state.pubsub.gcpReplicas}
+                      onChange={(e) => updateNested('pubsub', 'gcpReplicas', e.target.value)}
+                      placeholder="1"
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className={styles.hint}>
+                  Choose how S3 object notifications are ingested. HTTP provides a webhook endpoint. SQS polls from an AWS SQS queue.
+                </p>
+                <div className={styles.providerSelect}>
+                  <button
+                    className={`${styles.providerBtn} ${state.pubsub.type === 'http' ? styles.active : ''}`}
+                    onClick={() => updateNested('pubsub', 'type', 'http')}
+                  >
+                    HTTP (Webhook)
+                  </button>
+                  <button
+                    className={`${styles.providerBtn} ${state.pubsub.type === 'sqs' ? styles.active : ''}`}
+                    onClick={() => updateNested('pubsub', 'type', 'sqs')}
+                  >
+                    SQS
+                  </button>
+                </div>
+
+                {state.pubsub.type === 'http' && (
+                  <div className={styles.formGrid}>
+                    <div className={styles.formGroup}>
+                      <label>Replicas</label>
+                      <input
+                        type="text"
+                        value={state.pubsub.httpReplicas}
+                        onChange={(e) => updateNested('pubsub', 'httpReplicas', e.target.value)}
+                        placeholder="2"
+                      />
+                      <span className={styles.hint}>Recommend at least 2 for production</span>
+                    </div>
+                  </div>
+                )}
+
+                {state.pubsub.type === 'sqs' && (
+                  <div className={styles.formGrid}>
+                    <div className={`${styles.formGroup} ${styles.fullWidth}`}>
+                      <label>SQS Queue URL <span className={styles.required}>*</span></label>
+                      <input
+                        type="text"
+                        value={state.pubsub.sqsQueueURL}
+                        onChange={(e) => updateNested('pubsub', 'sqsQueueURL', e.target.value)}
+                        placeholder="https://sqs.us-east-2.amazonaws.com/123456789012/my-queue"
+                        className={!state.pubsub.sqsQueueURL.trim() ? styles.inputError : ''}
+                      />
+                    </div>
+                    <div className={styles.formGroup}>
+                      <label>Replicas</label>
+                      <input
+                        type="text"
+                        value={state.pubsub.sqsReplicas}
+                        onChange={(e) => updateNested('pubsub', 'sqsReplicas', e.target.value)}
+                        placeholder="2"
+                      />
+                    </div>
+                    <div className={styles.formGroup}>
+                      <label>Region</label>
+                      <input
+                        type="text"
+                        value={state.pubsub.sqsRegion}
+                        onChange={(e) => updateNested('pubsub', 'sqsRegion', e.target.value)}
+                        placeholder="Defaults to cloud provider region"
+                      />
+                      <span className={styles.hint}>Leave blank to use the AWS region above</span>
+                    </div>
+                    <div className={styles.formGroup}>
+                      <label>Role ARN</label>
+                      <input
+                        type="text"
+                        value={state.pubsub.sqsRoleARN}
+                        onChange={(e) => updateNested('pubsub', 'sqsRoleARN', e.target.value)}
+                        placeholder="arn:aws:iam::123456789012:role/my-role"
+                      />
+                      <span className={styles.hint}>Optional IAM role to assume for SQS access</span>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
           </section>
 
       {/* Generated YAML Output */}
@@ -804,15 +894,7 @@ export default function LakerunnerHelmValuesWizard() {
         {yaml && (
           <div className={styles.installInstructions}>
             <h4>Installation Commands</h4>
-            {state.enableKeda && (
-              <>
-                <h4>Step 1: Install KEDA (Required)</h4>
-                <p style={{ marginBottom: '1rem' }}>
-                  Follow the official KEDA installation guide: <a href="https://keda.sh/docs/latest/deploy/" target="_blank" rel="noopener noreferrer">https://keda.sh/docs/latest/deploy/</a>
-                </p>
-              </>
-            )}
-            <h4>{state.enableKeda ? 'Step 2: Install Lakerunner' : 'Install Lakerunner'}</h4>
+            <h4>Install Lakerunner</h4>
             <pre className={styles.codeBlock}>
 {`# Save the above values.yaml, then run:
 helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \\

--- a/components/__tests__/helm-validation.test.ts
+++ b/components/__tests__/helm-validation.test.ts
@@ -9,14 +9,21 @@ import {
 } from '../../lib/generateValuesYaml';
 
 // These tests validate that the wizard-generated YAML can be successfully
-// templated with the actual Lakerunner helm chart using `helm template`
+// templated with the actual Lakerunner helm chart using `helm template`.
+// Uses the local chart at ../charts/lakerunner/ for speed.
+
+const CHART_PATH = path.resolve(__dirname, '../../../charts/lakerunner');
 
 describe('Helm Template Validation', () => {
-  const CHART_URL = 'oci://public.ecr.aws/cardinalhq.io/lakerunner';
   let tempDir: string;
+  let chartAvailable: boolean;
 
   beforeAll(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lakerunner-test-'));
+    chartAvailable = fs.existsSync(path.join(CHART_PATH, 'Chart.yaml'));
+    if (!chartAvailable) {
+      console.warn(`Skipping helm template tests: chart not found at ${CHART_PATH}`);
+    }
   });
 
   afterAll(() => {
@@ -29,7 +36,7 @@ describe('Helm Template Validation', () => {
     const valuesFile = path.join(tempDir, `${testName}-values.yaml`);
     fs.writeFileSync(valuesFile, yamlContent);
 
-    const result = spawnSync('helm', ['template', testName, CHART_URL, '--values', valuesFile], {
+    const result = spawnSync('helm', ['template', testName, CHART_PATH, '--values', valuesFile], {
       encoding: 'utf-8',
       timeout: 30000,
     });
@@ -41,8 +48,7 @@ describe('Helm Template Validation', () => {
     };
   }
 
-  // Helper to create a valid POC base state
-  function createValidPOCState(): WizardState {
+  function createValidAWSState(): WizardState {
     const state = createDefaultState();
     state.installType = 'poc';
     state.cloudProvider = 'aws';
@@ -76,147 +82,188 @@ describe('Helm Template Validation', () => {
       sslMode: 'require',
       existingSecretName: '',
     };
-    state.kafka = {
-      credentialMode: 'create',
-      brokers: 'kafka-1:9092,kafka-2:9092',
-      saslMechanism: 'SCRAM-SHA-256',
-      username: 'kafka-user',
-      password: 'kafkapassword789',
-      useTls: true,
-      existingSecretName: '',
+    state.license = {
+      mode: 'create',
+      secretName: 'lakerunner-license',
+      data: 'b64:dGVzdGxpY2Vuc2VkYXRh',
     };
-    state.enableKeda = true;
+    state.pubsub = {
+      type: 'http',
+      httpReplicas: '2',
+      sqsReplicas: '2',
+      sqsQueueURL: '',
+      sqsRegion: '',
+      sqsRoleARN: '',
+      gcpReplicas: '1',
+      gcpProjectID: '',
+      gcpSubscriptionID: '',
+    };
+    state.scaling = { processLogsMax: '10', processMetricsMax: '10', processTracesMax: '10' };
     state.enableGrafana = true;
     state.enableCollector = true;
-    state.enableCardinalMonitoring = false;
-    state.cardinalApiKey = '';
     return state;
   }
 
-  describe('AWS Configurations', () => {
-    test('POC with AWS create credentials passes helm template', () => {
-      const state = createValidPOCState();
-      state.aws.credentialMode = 'create';
+  function createValidGCPState(): WizardState {
+    const state = createValidAWSState();
+    state.cloudProvider = 'gcp';
+    state.storage.region = 'us-central1';
+    state.gcp = {
+      credentialMode: 'workload_identity',
+      serviceAccountJson: '',
+      existingSecretName: '',
+    };
+    state.pubsub = {
+      type: 'http',
+      httpReplicas: '2',
+      sqsReplicas: '2',
+      sqsQueueURL: '',
+      sqsRegion: '',
+      sqsRoleARN: '',
+      gcpReplicas: '1',
+      gcpProjectID: 'my-project-123',
+      gcpSubscriptionID: 'my-subscription',
+    };
+    return state;
+  }
 
+  function skipIfNoChart() {
+    if (!chartAvailable) {
+      return true;
+    }
+    return false;
+  }
+
+  describe('AWS + HTTP PubSub', () => {
+    test('POC with AWS create credentials + HTTP pubsub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'aws-create-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'aws-create-http');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
       expect(result.output).toContain('kind: Deployment');
-    }, 60000);
+    }, 30000);
 
-    test('POC with AWS existing secret passes helm template', () => {
-      const state = createValidPOCState();
+    test('POC with AWS existing secret + HTTP pubsub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
       state.aws.credentialMode = 'existing';
       state.aws.existingSecretName = 'aws-credentials';
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'aws-existing-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'aws-existing-http');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-    }, 60000);
+    }, 30000);
 
-    test('POC with EKS IRSA passes helm template', () => {
-      const state = createValidPOCState();
+    test('POC with EKS IRSA + HTTP pubsub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
       state.aws.credentialMode = 'eks';
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'aws-eks-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'aws-eks-http');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-    }, 60000);
+    }, 30000);
+  });
+
+  describe('AWS + SQS PubSub', () => {
+    test('POC with AWS create credentials + SQS pubsub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = 'https://sqs.us-east-1.amazonaws.com/123456789012/my-queue';
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'aws-create-sqs');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
+
+    test('POC with EKS IRSA + SQS with roleARN', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.aws.credentialMode = 'eks';
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = 'https://sqs.us-east-2.amazonaws.com/123456789012/q';
+      state.pubsub.sqsRegion = 'us-east-2';
+      state.pubsub.sqsRoleARN = 'arn:aws:iam::123456789012:role/my-role';
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'aws-eks-sqs-role');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
   });
 
   describe('GCP Configurations', () => {
-    test('POC with GCP Workload Identity passes helm template', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.storage.region = 'us-central1';
-      state.gcp = {
-        credentialMode: 'workload_identity',
-        serviceAccountJson: '',
-        existingSecretName: '',
-      };
+    test('POC with GCP Workload Identity + GCP Pub/Sub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidGCPState();
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'gcp-workload-identity-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'gcp-workload-identity');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
       expect(result.output).toContain('kind: Deployment');
-    }, 60000);
+    }, 30000);
 
-    test('POC with GCP existing secret passes helm template', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.storage.region = 'us-central1';
-      state.gcp = {
-        credentialMode: 'existing',
-        serviceAccountJson: '',
-        existingSecretName: 'my-gcp-credentials',
-      };
+    test('POC with GCP existing secret + GCP Pub/Sub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidGCPState();
+      state.gcp.credentialMode = 'existing';
+      state.gcp.existingSecretName = 'my-gcp-credentials';
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'gcp-existing-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'gcp-existing');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-    }, 60000);
+    }, 30000);
 
-    test('POC with GCP service account JSON passes helm template', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.storage.region = 'us-central1';
-      state.gcp = {
-        credentialMode: 'service_account',
-        serviceAccountJson: '{"type":"service_account","project_id":"test-project","private_key_id":"key123"}',
-        existingSecretName: '',
-      };
+    test('POC with GCP service account JSON + GCP Pub/Sub', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidGCPState();
+      state.gcp.credentialMode = 'service_account';
+      state.gcp.serviceAccountJson = '{"type":"service_account","project_id":"test-project","private_key_id":"key123"}';
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'gcp-service-account-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'gcp-service-account');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-    }, 60000);
+    }, 30000);
   });
 
-  describe('Production Configuration', () => {
-    test('Production with existing secrets passes helm template', () => {
-      const state = createValidPOCState();
+  describe('Production Configurations', () => {
+    test('Production AWS with existing secrets + HTTP', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
       state.installType = 'production';
       state.aws.credentialMode = 'existing';
       state.aws.existingSecretName = 'aws-credentials';
@@ -224,91 +271,20 @@ describe('Helm Template Validation', () => {
       state.lrdb.existingSecretName = 'lrdb-credentials';
       state.configdb.credentialMode = 'existing';
       state.configdb.existingSecretName = 'configdb-credentials';
-      state.kafka.credentialMode = 'existing';
-      state.kafka.existingSecretName = 'kafka-credentials';
       state.enableGrafana = false;
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'production-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'prod-aws-http');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-      // Production should have replica settings
-      expect(yaml).toContain('replicas: 3');
-    }, 60000);
-  });
+    }, 30000);
 
-  describe('KEDA Configuration', () => {
-    test('Configuration without KEDA passes helm template', () => {
-      const state = createValidPOCState();
-      state.enableKeda = false;
+    test('Production AWS with existing secrets + SQS', () => {
+      if (skipIfNoChart()) return;
 
-      const yaml = generateValuesYaml(state);
-      expect(yaml).not.toBeNull();
-      expect(yaml).toContain('mode: "disabled"');
-
-      const result = validateWithHelm(yaml!, 'no-keda-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
-      expect(result.success).toBe(true);
-      // Should not contain ScaledObject when KEDA disabled
-      expect(result.output).not.toContain('kind: ScaledObject');
-    }, 60000);
-  });
-
-  describe('Cardinal Monitoring Configuration', () => {
-    test('POC without Cardinal monitoring passes helm template', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = false;
-      state.cardinalApiKey = '';
-
-      const yaml = generateValuesYaml(state);
-      expect(yaml).not.toBeNull();
-      expect(yaml).not.toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-
-      const result = validateWithHelm(yaml!, 'no-monitoring-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
-      expect(result.success).toBe(true);
-      expect(result.output).toContain('kind: Deployment');
-    }, 60000);
-
-    test('POC with Cardinal monitoring passes helm template and includes env vars', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = true;
-      state.cardinalApiKey = 'test-cardinal-api-key-12345';
-
-      const yaml = generateValuesYaml(state);
-      expect(yaml).not.toBeNull();
-      expect(yaml).toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-      expect(yaml).toContain('x-cardinalhq-api-key=test-cardinal-api-key-12345');
-
-      const result = validateWithHelm(yaml!, 'with-monitoring-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
-      expect(result.success).toBe(true);
-      expect(result.output).toContain('kind: Deployment');
-      // Verify env vars are attached to deployments
-      expect(result.output).toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-      expect(result.output).toContain('otelhttp.intake.us-east-2.aws.cardinalhq.io');
-    }, 60000);
-
-    test('Production with Cardinal monitoring passes helm template', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.installType = 'production';
       state.aws.credentialMode = 'existing';
       state.aws.existingSecretName = 'aws-credentials';
@@ -316,22 +292,95 @@ describe('Helm Template Validation', () => {
       state.lrdb.existingSecretName = 'lrdb-credentials';
       state.configdb.credentialMode = 'existing';
       state.configdb.existingSecretName = 'configdb-credentials';
-      state.kafka.credentialMode = 'existing';
-      state.kafka.existingSecretName = 'kafka-credentials';
-      state.enableCardinalMonitoring = true;
-      state.cardinalApiKey = 'prod-cardinal-api-key-12345';
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = 'https://sqs.us-east-1.amazonaws.com/123456789012/q';
+      state.enableGrafana = false;
 
       const yaml = generateValuesYaml(state);
       expect(yaml).not.toBeNull();
 
-      const result = validateWithHelm(yaml!, 'production-monitoring-test');
-
-      if (!result.success) {
-        console.error('Helm template error:', result.error);
-      }
-
+      const result = validateWithHelm(yaml!, 'prod-aws-sqs');
+      if (!result.success) console.error('Helm error:', result.error);
       expect(result.success).toBe(true);
-      expect(result.output).toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-    }, 60000);
+    }, 30000);
+
+    test('Production GCP with workload identity', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidGCPState();
+      state.installType = 'production';
+      state.lrdb.credentialMode = 'existing';
+      state.lrdb.existingSecretName = 'lrdb-credentials';
+      state.configdb.credentialMode = 'existing';
+      state.configdb.existingSecretName = 'configdb-credentials';
+      state.enableGrafana = false;
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'prod-gcp');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
+  });
+
+  describe('License Configurations', () => {
+    test('Inline license passes helm template', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.license = { mode: 'create', secretName: 'lakerunner-license', data: 'b64:dGVzdGxpY2Vuc2VkYXRh' };
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'license-inline');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
+
+    test('Existing license secret passes helm template', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.license = { mode: 'existing', secretName: 'my-license-secret', data: '' };
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'license-existing');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
+  });
+
+  describe('Grafana Toggle', () => {
+    test('Grafana enabled passes helm template', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.enableGrafana = true;
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'grafana-enabled');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
+
+    test('Grafana disabled passes helm template', () => {
+      if (skipIfNoChart()) return;
+
+      const state = createValidAWSState();
+      state.enableGrafana = false;
+
+      const yaml = generateValuesYaml(state);
+      expect(yaml).not.toBeNull();
+
+      const result = validateWithHelm(yaml!, 'grafana-disabled');
+      if (!result.success) console.error('Helm error:', result.error);
+      expect(result.success).toBe(true);
+    }, 30000);
   });
 });

--- a/lib/__tests__/generateValuesYaml.test.ts
+++ b/lib/__tests__/generateValuesYaml.test.ts
@@ -4,11 +4,12 @@ import {
   isValidCollectorName,
   isValidUUID,
   isValidPort,
+  isValidLicenseData,
   type WizardState,
 } from '../generateValuesYaml';
 
-// Helper to create a valid POC base state
-function createValidPOCState(): WizardState {
+// Helper to create a valid base state for AWS
+function createValidAWSState(): WizardState {
   const state = createDefaultState();
   state.installType = 'poc';
   state.cloudProvider = 'aws';
@@ -42,20 +43,48 @@ function createValidPOCState(): WizardState {
     sslMode: 'require',
     existingSecretName: '',
   };
-  state.kafka = {
-    credentialMode: 'create',
-    brokers: 'kafka-1:9092,kafka-2:9092',
-    saslMechanism: 'SCRAM-SHA-256',
-    username: 'kafka-user',
-    password: 'kafkapassword789',
-    useTls: true,
-    existingSecretName: '',
+  state.license = {
+    mode: 'create',
+    secretName: 'lakerunner-license',
+    data: 'b64:dGVzdGxpY2Vuc2VkYXRh',
   };
-  state.enableKeda = true;
+  state.pubsub = {
+    type: 'http',
+    httpReplicas: '2',
+    sqsReplicas: '2',
+    sqsQueueURL: '',
+    sqsRegion: '',
+    sqsRoleARN: '',
+    gcpReplicas: '1',
+    gcpProjectID: '',
+    gcpSubscriptionID: '',
+  };
   state.enableGrafana = true;
   state.enableCollector = true;
-  state.enableCardinalMonitoring = false;
-  state.cardinalApiKey = '';
+  return state;
+}
+
+// Helper to create a valid base state for GCP
+function createValidGCPState(): WizardState {
+  const state = createValidAWSState();
+  state.cloudProvider = 'gcp';
+  state.storage.region = 'us-central1';
+  state.gcp = {
+    credentialMode: 'workload_identity',
+    serviceAccountJson: '',
+    existingSecretName: '',
+  };
+  state.pubsub = {
+    type: 'http',
+    httpReplicas: '2',
+    sqsReplicas: '2',
+    sqsQueueURL: '',
+    sqsRegion: '',
+    sqsRoleARN: '',
+    gcpReplicas: '1',
+    gcpProjectID: 'my-project-123',
+    gcpSubscriptionID: 'my-subscription',
+  };
   return state;
 }
 
@@ -109,12 +138,77 @@ describe('Validation Functions', () => {
       expect(isValidPort('')).toBe(false);
     });
   });
+
+  describe('isValidLicenseData', () => {
+    test('accepts b64: prefix', () => {
+      expect(isValidLicenseData('b64:dGVzdA==')).toBe(true);
+    });
+
+    test('accepts z64: prefix', () => {
+      expect(isValidLicenseData('z64:dGVzdA==')).toBe(true);
+    });
+
+    test('rejects empty string', () => {
+      expect(isValidLicenseData('')).toBe(false);
+    });
+
+    test('rejects data without valid prefix', () => {
+      expect(isValidLicenseData('dGVzdA==')).toBe(false);
+      expect(isValidLicenseData('x64:dGVzdA==')).toBe(false);
+    });
+  });
 });
 
 describe('generateValuesYaml', () => {
+  describe('License Configuration', () => {
+    test('generates inline license with create mode', () => {
+      const state = createValidAWSState();
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('license:');
+      expect(yaml).toContain('create: true');
+      expect(yaml).toContain('data: "b64:dGVzdGxpY2Vuc2VkYXRh"');
+    });
+
+    test('generates existing secret license', () => {
+      const state = createValidAWSState();
+      state.license = { mode: 'existing', secretName: 'my-license-secret', data: '' };
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('license:');
+      expect(yaml).toContain('create: false');
+      expect(yaml).toContain('secretName: "my-license-secret"');
+    });
+
+    test('returns null when license data missing for create mode', () => {
+      const state = createValidAWSState();
+      state.license = { mode: 'create', secretName: 'lakerunner-license', data: '' };
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+
+    test('returns null when license data has wrong prefix', () => {
+      const state = createValidAWSState();
+      state.license = { mode: 'create', secretName: 'lakerunner-license', data: 'invalid-data' };
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+
+    test('returns null when existing secret name empty', () => {
+      const state = createValidAWSState();
+      state.license = { mode: 'existing', secretName: '', data: '' };
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+  });
+
   describe('AWS Cloud Provider', () => {
     test('generates EKS IRSA config (inject: false, create: false)', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.aws.credentialMode = 'eks';
 
       const yaml = generateValuesYaml(state);
@@ -124,11 +218,10 @@ describe('generateValuesYaml', () => {
       expect(yaml).toContain('inject: false');
       expect(yaml).toContain('create: false');
       expect(yaml).not.toContain('accessKeyId');
-      // Note: secretName appears in apiKeys section, which is correct
     });
 
     test('generates existing secret config (inject: true, create: false, secretName)', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.aws.credentialMode = 'existing';
       state.aws.existingSecretName = 'my-aws-secret';
 
@@ -143,7 +236,7 @@ describe('generateValuesYaml', () => {
     });
 
     test('generates create secret config (inject: true, create: true, credentials)', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.aws.credentialMode = 'create';
 
       const yaml = generateValuesYaml(state);
@@ -159,13 +252,7 @@ describe('generateValuesYaml', () => {
 
   describe('GCP Cloud Provider', () => {
     test('generates Workload Identity config (inject: false, create: false)', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.gcp = {
-        credentialMode: 'workload_identity',
-        serviceAccountJson: '',
-        existingSecretName: '',
-      };
+      const state = createValidGCPState();
 
       const yaml = generateValuesYaml(state);
 
@@ -175,12 +262,10 @@ describe('generateValuesYaml', () => {
       expect(yaml).toContain('inject: false');
       expect(yaml).toContain('create: false');
       expect(yaml).not.toContain('serviceAccountJson');
-      // Note: secretName appears in apiKeys section, which is correct
     });
 
     test('generates existing secret config (inject: true, create: false, secretName)', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
+      const state = createValidGCPState();
       state.gcp = {
         credentialMode: 'existing',
         serviceAccountJson: '',
@@ -191,7 +276,6 @@ describe('generateValuesYaml', () => {
 
       expect(yaml).not.toBeNull();
       expect(yaml).toContain('provider: "gcp"');
-      expect(yaml).toContain('gcp:');
       expect(yaml).toContain('inject: true');
       expect(yaml).toContain('create: false');
       expect(yaml).toContain('secretName: "my-gcp-credentials"');
@@ -199,8 +283,7 @@ describe('generateValuesYaml', () => {
     });
 
     test('generates service account JSON config (inject: true, create: true, serviceAccountJson)', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
+      const state = createValidGCPState();
       state.gcp = {
         credentialMode: 'service_account',
         serviceAccountJson: '{"type":"service_account","project_id":"test"}',
@@ -211,7 +294,6 @@ describe('generateValuesYaml', () => {
 
       expect(yaml).not.toBeNull();
       expect(yaml).toContain('provider: "gcp"');
-      expect(yaml).toContain('gcp:');
       expect(yaml).toContain('inject: true');
       expect(yaml).toContain('create: true');
       expect(yaml).toContain('serviceAccountJson:');
@@ -219,140 +301,231 @@ describe('generateValuesYaml', () => {
     });
   });
 
-  describe('KEDA Configuration', () => {
-    test('generates keda mode when enabled', () => {
-      const state = createValidPOCState();
-      state.enableKeda = true;
+  describe('Scaling Configuration', () => {
+    test('generates processLogs/processMetrics/processTraces with autoscaling', () => {
+      const state = createValidAWSState();
+      state.scaling = { processLogsMax: '5', processMetricsMax: '8', processTracesMax: '3' };
 
       const yaml = generateValuesYaml(state);
 
-      expect(yaml).toContain('mode: "keda"');
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('processLogs:');
+      expect(yaml).toContain('processMetrics:');
+      expect(yaml).toContain('processTraces:');
+      expect(yaml).toContain('minReplicas: 1');
+      expect(yaml).toContain('maxReplicas: 5');
+      expect(yaml).toContain('maxReplicas: 8');
+      expect(yaml).toContain('maxReplicas: 3');
     });
 
-    test('generates disabled mode when KEDA disabled', () => {
-      const state = createValidPOCState();
-      state.enableKeda = false;
+    test('does not generate old ingest* or keda keys', () => {
+      const state = createValidAWSState();
 
       const yaml = generateValuesYaml(state);
 
-      expect(yaml).toContain('mode: "disabled"');
+      expect(yaml).not.toBeNull();
+      expect(yaml).not.toContain('ingestLogs');
+      expect(yaml).not.toContain('ingestMetrics');
+      expect(yaml).not.toContain('ingestTraces');
+      expect(yaml).not.toContain('mode: "keda"');
+      expect(yaml).not.toContain('mode: "disabled"');
+    });
+  });
+
+  describe('PubSub Configuration', () => {
+    test('generates HTTP pubsub for AWS', () => {
+      const state = createValidAWSState();
+      state.pubsub.type = 'http';
+      state.pubsub.httpReplicas = '3';
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('pubsub:');
+      expect(yaml).toContain('HTTP:');
+      expect(yaml).toContain('enabled: true');
+      expect(yaml).toContain('replicas: 3');
+    });
+
+    test('generates SQS pubsub for AWS', () => {
+      const state = createValidAWSState();
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = 'https://sqs.us-east-1.amazonaws.com/123456789012/my-queue';
+      state.pubsub.sqsReplicas = '2';
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('pubsub:');
+      expect(yaml).toContain('SQS:');
+      expect(yaml).toContain('enabled: true');
+      expect(yaml).toContain('queueURL: "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue"');
+    });
+
+    test('generates SQS with optional region and roleARN', () => {
+      const state = createValidAWSState();
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = 'https://sqs.us-east-2.amazonaws.com/123456789012/q';
+      state.pubsub.sqsRegion = 'us-east-2';
+      state.pubsub.sqsRoleARN = 'arn:aws:iam::123456789012:role/my-role';
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('region: "us-east-2"');
+      expect(yaml).toContain('roleARN: "arn:aws:iam::123456789012:role/my-role"');
+    });
+
+    test('returns null when SQS selected but queueURL empty', () => {
+      const state = createValidAWSState();
+      state.pubsub.type = 'sqs';
+      state.pubsub.sqsQueueURL = '';
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+
+    test('generates GCP Pub/Sub for GCP provider', () => {
+      const state = createValidGCPState();
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('pubsub:');
+      expect(yaml).toContain('GCP:');
+      expect(yaml).toContain('enabled: true');
+      expect(yaml).toContain('projectID: "my-project-123"');
+      expect(yaml).toContain('subscriptionID: "my-subscription"');
+    });
+
+    test('returns null when GCP missing projectID', () => {
+      const state = createValidGCPState();
+      state.pubsub.gcpProjectID = '';
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+
+    test('returns null when GCP missing subscriptionID', () => {
+      const state = createValidGCPState();
+      state.pubsub.gcpSubscriptionID = '';
+
+      expect(generateValuesYaml(state)).toBeNull();
     });
   });
 
   describe('Grafana Configuration', () => {
     test('includes grafana apiKey when enabled', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.enableGrafana = true;
 
       const yaml = generateValuesYaml(state);
 
       expect(yaml).toContain('grafana:');
       expect(yaml).toContain('enabled: true');
-      // Grafana uses the main apiKey
       expect(yaml).toContain(`apiKey: "${state.apiKey}"`);
     });
 
     test('does not include apiKey when grafana disabled', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.enableGrafana = false;
 
       const yaml = generateValuesYaml(state);
 
       expect(yaml).toContain('grafana:');
       expect(yaml).toContain('enabled: false');
-      expect(yaml).not.toContain('cardinal:');
     });
   });
 
-  describe('Production Configuration', () => {
-    test('includes replica settings for production', () => {
-      const state = createValidPOCState();
-      state.installType = 'production';
+  describe('Database Configuration', () => {
+    test('generates database with create mode', () => {
+      const state = createValidAWSState();
 
       const yaml = generateValuesYaml(state);
 
-      expect(yaml).toContain('ingestLogs:');
-      expect(yaml).toContain('replicas: 3');
-      expect(yaml).toContain('queryApi:');
-      expect(yaml).toContain('replicas: 2');
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('database:');
+      expect(yaml).toContain('host: "lakerunner-db.example.com"');
+      expect(yaml).toContain('password: "testpassword123"');
     });
 
-    test('does not include replica settings for POC', () => {
-      const state = createValidPOCState();
-      state.installType = 'poc';
+    test('generates database with existing secret', () => {
+      const state = createValidAWSState();
+      state.lrdb.credentialMode = 'existing';
+      state.lrdb.existingSecretName = 'lrdb-credentials';
 
       const yaml = generateValuesYaml(state);
 
-      expect(yaml).not.toContain('ingestLogs:');
-      expect(yaml).not.toContain('replicas: 3');
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('secretName: "lrdb-credentials"');
+      expect(yaml).not.toContain('password: "testpassword123"');
+    });
+
+    test('generates configdb with create mode', () => {
+      const state = createValidAWSState();
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).toContain('configdb:');
+      expect(yaml).toContain('host: "config-db.example.com"');
+    });
+
+    test('returns null when lrdb host empty', () => {
+      const state = createValidAWSState();
+      state.lrdb.host = '';
+
+      expect(generateValuesYaml(state)).toBeNull();
+    });
+
+    test('returns null when configdb host empty', () => {
+      const state = createValidAWSState();
+      state.configdb.host = '';
+
+      expect(generateValuesYaml(state)).toBeNull();
     });
   });
 
   describe('Validation', () => {
     test('returns null when collector name is invalid', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.collectorName = 'default';
 
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).toBeNull();
+      expect(generateValuesYaml(state)).toBeNull();
     });
 
     test('returns null when organization ID is invalid', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
       state.organizationId = 'not-a-uuid';
 
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).toBeNull();
+      expect(generateValuesYaml(state)).toBeNull();
     });
 
     test('returns null when GCP service account mode has no JSON', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.gcp = {
-        credentialMode: 'service_account',
-        serviceAccountJson: '',  // Empty - should fail validation
-        existingSecretName: '',
-      };
+      const state = createValidGCPState();
+      state.gcp.credentialMode = 'service_account';
+      state.gcp.serviceAccountJson = '';
 
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).toBeNull();
+      expect(generateValuesYaml(state)).toBeNull();
     });
 
     test('returns null when GCP existing secret mode has no secret name', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.gcp = {
-        credentialMode: 'existing',
-        serviceAccountJson: '',
-        existingSecretName: '',  // Empty - should fail validation
-      };
+      const state = createValidGCPState();
+      state.gcp.credentialMode = 'existing';
+      state.gcp.existingSecretName = '';
 
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).toBeNull();
+      expect(generateValuesYaml(state)).toBeNull();
     });
 
     test('passes validation for GCP workload identity with no credentials', () => {
-      const state = createValidPOCState();
-      state.cloudProvider = 'gcp';
-      state.gcp = {
-        credentialMode: 'workload_identity',
-        serviceAccountJson: '',  // Empty is OK for workload identity
-        existingSecretName: '',
-      };
+      const state = createValidGCPState();
+      state.gcp.credentialMode = 'workload_identity';
 
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).not.toBeNull();
+      expect(generateValuesYaml(state)).not.toBeNull();
     });
   });
 
   describe('Storage Profiles', () => {
     test('includes organization_id and collector_name in storageProfiles', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
 
       const yaml = generateValuesYaml(state);
 
@@ -364,64 +537,29 @@ describe('generateValuesYaml', () => {
     });
   });
 
-  describe('Cardinal Monitoring Configuration', () => {
-    test('includes OTEL env vars when Cardinal monitoring enabled with valid API key', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = true;
-      state.cardinalApiKey = 'test-cardinal-api-key-12345';
-
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).not.toBeNull();
-      expect(yaml).toContain('env:');
-      expect(yaml).toContain('- name: OTEL_EXPORTER_OTLP_ENDPOINT');
-      expect(yaml).toContain('value: "https://otelhttp.intake.us-east-2.aws.cardinalhq.io"');
-      expect(yaml).toContain('- name: OTEL_EXPORTER_OTLP_HEADERS');
-      expect(yaml).toContain('value: "x-cardinalhq-api-key=test-cardinal-api-key-12345"');
-    });
-
-    test('does not include OTEL env vars when Cardinal monitoring disabled', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = false;
-      state.cardinalApiKey = '';
-
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).not.toBeNull();
-      expect(yaml).not.toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-      expect(yaml).not.toContain('OTEL_EXPORTER_OTLP_HEADERS');
-    });
-
-    test('returns null when Cardinal monitoring enabled but API key too short', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = true;
-      state.cardinalApiKey = 'short';  // Less than 10 characters
-
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).toBeNull();
-    });
-
-    test('generates valid YAML when Cardinal monitoring enabled with 10+ char API key', () => {
-      const state = createValidPOCState();
-      state.enableCardinalMonitoring = true;
-      state.cardinalApiKey = '1234567890';  // Exactly 10 characters
-
-      const yaml = generateValuesYaml(state);
-
-      expect(yaml).not.toBeNull();
-      expect(yaml).toContain('OTEL_EXPORTER_OTLP_ENDPOINT');
-    });
-  });
-
   describe('Collector Configuration', () => {
     test('collector is always disabled in generated YAML', () => {
-      const state = createValidPOCState();
+      const state = createValidAWSState();
 
       const yaml = generateValuesYaml(state);
 
       expect(yaml).toContain('collector:');
       expect(yaml).toContain('enabled: false');
+    });
+  });
+
+  describe('No removed fields in output', () => {
+    test('does not contain kafka, keda, or cardinal monitoring fields', () => {
+      const state = createValidAWSState();
+
+      const yaml = generateValuesYaml(state);
+
+      expect(yaml).not.toBeNull();
+      expect(yaml).not.toContain('kafka:');
+      expect(yaml).not.toContain('brokers:');
+      expect(yaml).not.toContain('sasl:');
+      expect(yaml).not.toContain('global:');
+      expect(yaml).not.toContain('OTEL_EXPORTER');
     });
   });
 });

--- a/lib/generateValuesYaml.ts
+++ b/lib/generateValuesYaml.ts
@@ -4,6 +4,9 @@ export type CloudProvider = 'aws' | 'gcp' | 'azure';
 export type AWSCredentialMode = 'create' | 'existing' | 'eks';
 export type GCPCredentialMode = 'workload_identity' | 'service_account' | 'existing';
 export type SecretMode = 'create' | 'existing';
+export type PubSubType = 'http' | 'sqs';
+export type GCPPubSubType = 'gcp';
+export type LicenseMode = 'create' | 'existing';
 
 export interface StorageConfig {
   bucket: string;
@@ -41,14 +44,28 @@ export interface PostgresConfig {
   existingSecretName: string;
 }
 
-export interface KafkaConfig {
-  credentialMode: SecretMode;
-  brokers: string;
-  saslMechanism: string;
-  username: string;
-  password: string;
-  useTls: boolean;
-  existingSecretName: string;
+export interface ScalingConfig {
+  processLogsMax: string;
+  processMetricsMax: string;
+  processTracesMax: string;
+}
+
+export interface PubSubConfig {
+  type: PubSubType;
+  httpReplicas: string;
+  sqsReplicas: string;
+  sqsQueueURL: string;
+  sqsRegion: string;
+  sqsRoleARN: string;
+  gcpReplicas: string;
+  gcpProjectID: string;
+  gcpSubscriptionID: string;
+}
+
+export interface LicenseConfig {
+  mode: LicenseMode;
+  secretName: string;
+  data: string;
 }
 
 export interface WizardState {
@@ -63,12 +80,11 @@ export interface WizardState {
   azure: AzureConfig;
   lrdb: PostgresConfig;
   configdb: PostgresConfig;
-  kafka: KafkaConfig;
-  enableKeda: boolean;
+  scaling: ScalingConfig;
+  pubsub: PubSubConfig;
+  license: LicenseConfig;
   enableGrafana: boolean;
   enableCollector: boolean;
-  enableCardinalMonitoring: boolean;
-  cardinalApiKey: string;
 }
 
 // Validation functions
@@ -87,13 +103,19 @@ export function isValidPort(port: string): boolean {
   return !isNaN(portNum) && portNum >= 1 && portNum <= 65535;
 }
 
+export function isValidLicenseData(data: string): boolean {
+  const trimmed = data.trim();
+  return trimmed.startsWith('b64:') || trimmed.startsWith('z64:');
+}
+
 export function isBasicsConfigured(state: WizardState): boolean {
   if (!isValidCollectorName(state.collectorName)) return false;
   if (!isValidUUID(state.organizationId)) return false;
   if (!state.apiKey.trim()) return false;
 
-  // Validate Cardinal monitoring API key if enabled
-  if (state.enableCardinalMonitoring && state.cardinalApiKey.trim().length < 10) return false;
+  // Validate license
+  if (state.license.mode === 'create' && !isValidLicenseData(state.license.data)) return false;
+  if (state.license.mode === 'existing' && !state.license.secretName.trim()) return false;
 
   // Validate storage configuration
   if (!state.storage.bucket.trim()) return false;
@@ -113,32 +135,29 @@ export function isBasicsConfigured(state: WizardState): boolean {
     } else if (state.gcp.credentialMode === 'existing') {
       if (!state.gcp.existingSecretName.trim()) return false;
     }
-    // workload_identity requires no additional fields
   }
 
-  // For POC and Production, validate database and Kafka configuration
-  if (state.installType === 'poc' || state.installType === 'production') {
-    // Validate lrdb
-    if (!state.lrdb.host.trim()) return false;
-    if (!isValidPort(state.lrdb.port)) return false;
-    if (!state.lrdb.database.trim()) return false;
-    if (!state.lrdb.username.trim()) return false;
-    if (state.lrdb.credentialMode === 'create' && !state.lrdb.password.trim()) return false;
-    if (state.lrdb.credentialMode === 'existing' && !state.lrdb.existingSecretName.trim()) return false;
+  // Validate database configuration
+  if (!state.lrdb.host.trim()) return false;
+  if (!isValidPort(state.lrdb.port)) return false;
+  if (!state.lrdb.database.trim()) return false;
+  if (!state.lrdb.username.trim()) return false;
+  if (state.lrdb.credentialMode === 'create' && !state.lrdb.password.trim()) return false;
+  if (state.lrdb.credentialMode === 'existing' && !state.lrdb.existingSecretName.trim()) return false;
 
-    // Validate configdb
-    if (!state.configdb.host.trim()) return false;
-    if (!isValidPort(state.configdb.port)) return false;
-    if (!state.configdb.database.trim()) return false;
-    if (!state.configdb.username.trim()) return false;
-    if (state.configdb.credentialMode === 'create' && !state.configdb.password.trim()) return false;
-    if (state.configdb.credentialMode === 'existing' && !state.configdb.existingSecretName.trim()) return false;
+  if (!state.configdb.host.trim()) return false;
+  if (!isValidPort(state.configdb.port)) return false;
+  if (!state.configdb.database.trim()) return false;
+  if (!state.configdb.username.trim()) return false;
+  if (state.configdb.credentialMode === 'create' && !state.configdb.password.trim()) return false;
+  if (state.configdb.credentialMode === 'existing' && !state.configdb.existingSecretName.trim()) return false;
 
-    // Validate kafka
-    if (!state.kafka.brokers.trim()) return false;
-    if (state.kafka.credentialMode === 'create' && !state.kafka.username.trim()) return false;
-    if (state.kafka.credentialMode === 'create' && !state.kafka.password.trim()) return false;
-    if (state.kafka.credentialMode === 'existing' && !state.kafka.existingSecretName.trim()) return false;
+  // Validate pubsub (required)
+  if (state.cloudProvider === 'gcp') {
+    if (!state.pubsub.gcpProjectID.trim()) return false;
+    if (!state.pubsub.gcpSubscriptionID.trim()) return false;
+  } else {
+    if (state.pubsub.type === 'sqs' && !state.pubsub.sqsQueueURL.trim()) return false;
   }
 
   return true;
@@ -158,36 +177,34 @@ export function createDefaultState(): WizardState {
     azure: { storageAccountName: '', storageAccountKey: '', containerName: '' },
     lrdb: { credentialMode: 'create', host: '', port: '5432', database: 'lakerunner', username: '', password: '', sslMode: 'require', existingSecretName: '' },
     configdb: { credentialMode: 'create', host: '', port: '5432', database: 'configdb', username: '', password: '', sslMode: 'require', existingSecretName: '' },
-    kafka: { credentialMode: 'create', brokers: '', saslMechanism: 'PLAIN', username: '', password: '', useTls: true, existingSecretName: '' },
-    enableKeda: true,
+    scaling: { processLogsMax: '10', processMetricsMax: '10', processTracesMax: '10' },
+    pubsub: { type: 'http', httpReplicas: '2', sqsReplicas: '2', sqsQueueURL: '', sqsRegion: '', sqsRoleARN: '', gcpReplicas: '1', gcpProjectID: '', gcpSubscriptionID: '' },
+    license: { mode: 'create', secretName: 'lakerunner-license', data: '' },
     enableGrafana: true,
     enableCollector: true,
-    enableCardinalMonitoring: true,
-    cardinalApiKey: '',
   };
 }
 
 // YAML generator
 export function generateValuesYaml(state: WizardState): string | null {
-  // Check if basics are configured
   if (!isBasicsConfigured(state)) {
     return null;
   }
 
   const lines: string[] = ['# Lakerunner Values Configuration', '# Generated by Cardinal Install Wizard', ''];
 
-  // Global settings
-  lines.push('global:');
-  lines.push('  autoscaling:');
-  lines.push(`    mode: "${state.enableKeda ? 'keda' : 'disabled'}"`);
-  if (state.enableCardinalMonitoring && state.cardinalApiKey.trim()) {
-    lines.push('  env:');
-    lines.push('    - name: OTEL_EXPORTER_OTLP_ENDPOINT');
-    lines.push('      value: "https://otelhttp.intake.us-east-2.aws.cardinalhq.io"');
-    lines.push('    - name: OTEL_EXPORTER_OTLP_HEADERS');
-    lines.push(`      value: "x-cardinalhq-api-key=${state.cardinalApiKey}"`);
+  // License
+  lines.push('license:');
+  if (state.license.mode === 'existing') {
+    lines.push('  create: false');
+    lines.push(`  secretName: "${state.license.secretName}"`);
+  } else {
+    lines.push('  create: true');
+    lines.push(`  secretName: "${state.license.secretName}"`);
+    lines.push(`  data: "${state.license.data.trim()}"`);
   }
   lines.push('');
+
 
   // API Keys
   lines.push('apiKeys:');
@@ -207,16 +224,13 @@ export function generateValuesYaml(state: WizardState): string | null {
     lines.push('  aws:');
     lines.push(`    region: "${state.storage.region}"`);
     if (state.aws.credentialMode === 'eks') {
-      // Use EKS-provided credentials (IRSA/Pod Identity)
       lines.push('    inject: false');
       lines.push('    create: false');
     } else if (state.aws.credentialMode === 'existing') {
-      // Use existing secret
       lines.push('    inject: true');
       lines.push('    create: false');
       lines.push(`    secretName: "${state.aws.existingSecretName}"`);
     } else {
-      // Create new secret
       lines.push('    inject: true');
       lines.push('    create: true');
       lines.push(`    accessKeyId: "${state.aws.accessKeyId}"`);
@@ -225,16 +239,13 @@ export function generateValuesYaml(state: WizardState): string | null {
   } else if (state.cloudProvider === 'gcp') {
     lines.push('  gcp:');
     if (state.gcp.credentialMode === 'workload_identity') {
-      // Workload Identity (recommended for GKE)
       lines.push('    inject: false');
       lines.push('    create: false');
     } else if (state.gcp.credentialMode === 'existing') {
-      // Existing secret with GOOGLE_APPLICATION_CREDENTIALS
       lines.push('    inject: true');
       lines.push('    create: false');
       lines.push(`    secretName: "${state.gcp.existingSecretName}"`);
     } else {
-      // Service Account JSON
       lines.push('    inject: true');
       lines.push('    create: true');
       lines.push(`    serviceAccountJson: '${state.gcp.serviceAccountJson}'`);
@@ -265,78 +276,85 @@ export function generateValuesYaml(state: WizardState): string | null {
   }
   lines.push('');
 
-  // Database configuration (POC and Production)
-  if (state.installType === 'poc' || state.installType === 'production') {
-    lines.push('database:');
-    if (state.lrdb.credentialMode === 'existing') {
-      lines.push('  create: false');
-      lines.push(`  secretName: "${state.lrdb.existingSecretName}"`);
-    } else {
-      lines.push('  create: true');
-    }
-    lines.push('  lrdb:');
-    lines.push(`    host: "${state.lrdb.host}"`);
-    lines.push(`    port: ${state.lrdb.port}`);
-    lines.push(`    name: "${state.lrdb.database}"`);
-    lines.push(`    username: "${state.lrdb.username}"`);
-    if (state.lrdb.credentialMode === 'create') {
-      lines.push(`    password: "${state.lrdb.password}"`);
-    }
-    lines.push(`    sslMode: "${state.lrdb.sslMode}"`);
-    lines.push('');
+  // Database configuration
+  lines.push('database:');
+  if (state.lrdb.credentialMode === 'existing') {
+    lines.push('  create: false');
+    lines.push(`  secretName: "${state.lrdb.existingSecretName}"`);
+  } else {
+    lines.push('  create: true');
+  }
+  lines.push('  lrdb:');
+  lines.push(`    host: "${state.lrdb.host}"`);
+  lines.push(`    port: ${state.lrdb.port}`);
+  lines.push(`    name: "${state.lrdb.database}"`);
+  lines.push(`    username: "${state.lrdb.username}"`);
+  if (state.lrdb.credentialMode === 'create') {
+    lines.push(`    password: "${state.lrdb.password}"`);
+  }
+  lines.push(`    sslMode: "${state.lrdb.sslMode}"`);
+  lines.push('');
 
-    lines.push('configdb:');
-    if (state.configdb.credentialMode === 'existing') {
-      lines.push('  create: false');
-      lines.push(`  secretName: "${state.configdb.existingSecretName}"`);
-    } else {
-      lines.push('  create: true');
-    }
-    lines.push('  lrdb:');
-    lines.push(`    host: "${state.configdb.host}"`);
-    lines.push(`    port: ${state.configdb.port}`);
-    lines.push(`    name: "${state.configdb.database}"`);
-    lines.push(`    username: "${state.configdb.username}"`);
-    if (state.configdb.credentialMode === 'create') {
-      lines.push(`    password: "${state.configdb.password}"`);
-    }
-    lines.push(`    sslMode: "${state.configdb.sslMode}"`);
-    lines.push('');
+  lines.push('configdb:');
+  if (state.configdb.credentialMode === 'existing') {
+    lines.push('  create: false');
+    lines.push(`  secretName: "${state.configdb.existingSecretName}"`);
+  } else {
+    lines.push('  create: true');
+  }
+  lines.push('  lrdb:');
+  lines.push(`    host: "${state.configdb.host}"`);
+  lines.push(`    port: ${state.configdb.port}`);
+  lines.push(`    name: "${state.configdb.database}"`);
+  lines.push(`    username: "${state.configdb.username}"`);
+  if (state.configdb.credentialMode === 'create') {
+    lines.push(`    password: "${state.configdb.password}"`);
+  }
+  lines.push(`    sslMode: "${state.configdb.sslMode}"`);
+  lines.push('');
 
-    lines.push('kafka:');
-    if (state.kafka.credentialMode === 'existing') {
-      lines.push('  create: false');
-      lines.push(`  secretName: "${state.kafka.existingSecretName}"`);
-    } else {
-      lines.push('  create: true');
-    }
-    lines.push(`  brokers: "${state.kafka.brokers}"`);
-    lines.push('  sasl:');
+  // Process service scaling
+  lines.push('processLogs:');
+  lines.push('  autoscaling:');
+  lines.push(`    minReplicas: 1`);
+  lines.push(`    maxReplicas: ${state.scaling.processLogsMax}`);
+  lines.push('');
+  lines.push('processMetrics:');
+  lines.push('  autoscaling:');
+  lines.push(`    minReplicas: 1`);
+  lines.push(`    maxReplicas: ${state.scaling.processMetricsMax}`);
+  lines.push('');
+  lines.push('processTraces:');
+  lines.push('  autoscaling:');
+  lines.push(`    minReplicas: 1`);
+  lines.push(`    maxReplicas: ${state.scaling.processTracesMax}`);
+  lines.push('');
+
+  // PubSub (ingestion)
+  lines.push('pubsub:');
+  if (state.cloudProvider === 'gcp') {
+    lines.push('  GCP:');
     lines.push('    enabled: true');
-    lines.push(`    mechanism: "${state.kafka.saslMechanism}"`);
-    if (state.kafka.credentialMode === 'create') {
-      lines.push(`    username: "${state.kafka.username}"`);
-      lines.push(`    password: "${state.kafka.password}"`);
+    lines.push(`    replicas: ${state.pubsub.gcpReplicas}`);
+    lines.push(`    projectID: "${state.pubsub.gcpProjectID}"`);
+    lines.push(`    subscriptionID: "${state.pubsub.gcpSubscriptionID}"`);
+  } else if (state.pubsub.type === 'http') {
+    lines.push('  HTTP:');
+    lines.push('    enabled: true');
+    lines.push(`    replicas: ${state.pubsub.httpReplicas}`);
+  } else if (state.pubsub.type === 'sqs') {
+    lines.push('  SQS:');
+    lines.push('    enabled: true');
+    lines.push(`    replicas: ${state.pubsub.sqsReplicas}`);
+    lines.push(`    queueURL: "${state.pubsub.sqsQueueURL}"`);
+    if (state.pubsub.sqsRegion.trim()) {
+      lines.push(`    region: "${state.pubsub.sqsRegion}"`);
     }
-    lines.push('  tls:');
-    lines.push(`    enabled: ${state.kafka.useTls}`);
-    lines.push('');
+    if (state.pubsub.sqsRoleARN.trim()) {
+      lines.push(`    roleARN: "${state.pubsub.sqsRoleARN}"`);
+    }
   }
-
-  // Production-specific settings
-  if (state.installType === 'production') {
-    lines.push('# Production replica settings');
-    lines.push('ingestLogs:');
-    lines.push('  replicas: 3');
-    lines.push('ingestMetrics:');
-    lines.push('  replicas: 3');
-    lines.push('ingestTraces:');
-    lines.push('  replicas: 3');
-    lines.push('');
-    lines.push('queryApi:');
-    lines.push('  replicas: 2');
-    lines.push('');
-  }
+  lines.push('');
 
   // Grafana settings
   lines.push('grafana:');


### PR DESCRIPTION
## Summary
- Remove Kafka (no longer in chart), KEDA/HPA (internal scaling now), and Cardinal monitoring opt-in (license handles it)
- Fix service names (`ingestLogs` → `processLogs`, etc.)
- Add license config (inline `b64:`/`z64:` blob or existing secret)
- Add required PubSub ingestion: HTTP/SQS for AWS, GCP Pub/Sub for GCP
- Compact scaling UI as a table with just max pods (min always 1)
- Tests validate all combinations against local chart

## Test plan
- [x] 46 unit tests pass
- [x] 15 helm template tests pass against real chart
- [x] `pnpm build` succeeds