### PR TITLE
Add packageManager field for pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "jest --watch",
     "test:links": "jest lib/__tests__/links.test.ts"
   },
+  "packageManager": "pnpm@10.30.1",
   "license": "MIT",
   "dependencies": {
     "next": "^14.2.21",


### PR DESCRIPTION
Fixes CI: pnpm/action-setup@v4 requires packageManager in package.json when version is not specified in the action config.