### PR TITLE
Add Lakerunner Quick Start guide

### DIFF
--- a/components/QuickStartSteps.module.css
+++ b/components/QuickStartSteps.module.css
@@ -1,0 +1,417 @@
+/* ── Wrapper ── */
+.wrapper {
+  --qs-orange: #ff5722;
+  --qs-amber: #ff9800;
+  --qs-gold: #ffc107;
+  --qs-surface: #faf9f7;
+  --qs-surface-elevated: #ffffff;
+  --qs-border: #e8e5e0;
+  --qs-text: #1a1715;
+  --qs-text-muted: #6b6560;
+  --qs-code-bg: #1e1e2e;
+  --qs-code-text: #cdd6f4;
+  margin: 0 -1.5rem;
+}
+
+:global(.dark) .wrapper {
+  --qs-surface: #141210;
+  --qs-surface-elevated: #1c1a17;
+  --qs-border: #2e2a26;
+  --qs-text: #ede8e3;
+  --qs-text-muted: #9b9590;
+  --qs-code-bg: #0d0d14;
+  --qs-code-text: #cdd6f4;
+}
+
+/* ── Hero ── */
+.hero {
+  position: relative;
+  padding: 3rem 2rem 2.5rem;
+  text-align: center;
+  overflow: hidden;
+  border-radius: 16px;
+  background: var(--qs-surface);
+  border: 1px solid var(--qs-border);
+  margin-bottom: 2rem;
+}
+
+.heroGlow {
+  position: absolute;
+  top: -60%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 500px;
+  height: 300px;
+  background: radial-gradient(ellipse, rgba(255, 87, 34, 0.15) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+:global(.dark) .heroGlow {
+  background: radial-gradient(ellipse, rgba(255, 87, 34, 0.1) 0%, transparent 70%);
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 14px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--qs-orange);
+  background: rgba(255, 87, 34, 0.08);
+  border: 1px solid rgba(255, 87, 34, 0.18);
+  margin-bottom: 1rem;
+}
+
+.heroBadgeDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--qs-orange);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.heroTitle {
+  font-size: 2rem;
+  font-weight: 750;
+  letter-spacing: -0.03em;
+  color: var(--qs-text);
+  margin: 0 0 0.5rem;
+  line-height: 1.15;
+  border: none !important;
+  padding-left: 0 !important;
+}
+
+.heroSub {
+  font-size: 1.05rem;
+  color: var(--qs-text-muted);
+  margin: 0;
+  max-width: 480px;
+  margin-inline: auto;
+  line-height: 1.6;
+}
+
+/* ── Prerequisites ── */
+.prereqs {
+  margin-bottom: 2.5rem;
+}
+
+.prereqTitle {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--qs-text-muted);
+  margin: 0 0 0.75rem 0.25rem;
+}
+
+.prereqGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .prereqGrid { grid-template-columns: 1fr; }
+}
+
+.prereqItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: var(--qs-surface);
+  border: 1px solid var(--qs-border);
+  transition: border-color 0.2s;
+}
+
+.prereqItem:hover {
+  border-color: var(--qs-orange);
+}
+
+.prereqIcon {
+  font-size: 1.3rem;
+  width: 32px;
+  text-align: center;
+  flex-shrink: 0;
+  color: var(--qs-orange);
+}
+
+.prereqItem strong {
+  display: block;
+  font-size: 0.88rem;
+  font-weight: 650;
+  color: var(--qs-text);
+}
+
+.prereqAlt {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--qs-text-muted);
+  margin-top: 1px;
+}
+
+.prereqAlt a {
+  color: var(--qs-orange);
+  text-decoration: none;
+}
+
+.prereqAlt a:hover {
+  text-decoration: underline;
+}
+
+/* ── Timeline ── */
+.timeline {
+  position: relative;
+  padding-bottom: 1rem;
+}
+
+.step {
+  display: flex;
+  gap: 1.25rem;
+  animation: fadeUp 0.4s ease-out both;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.stepRail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 52px;
+}
+
+.stepNumber {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  font-weight: 750;
+  color: var(--qs-orange);
+  background: rgba(255, 87, 34, 0.08);
+  border: 2px solid rgba(255, 87, 34, 0.2);
+  flex-shrink: 0;
+  transition: all 0.25s;
+}
+
+.step:hover .stepNumber {
+  background: rgba(255, 87, 34, 0.14);
+  border-color: var(--qs-orange);
+  transform: scale(1.06);
+}
+
+.stepLine {
+  width: 2px;
+  flex: 1;
+  min-height: 20px;
+  background: linear-gradient(to bottom, rgba(255, 87, 34, 0.25), var(--qs-border));
+  border-radius: 1px;
+}
+
+.stepBody {
+  flex: 1;
+  padding-bottom: 2rem;
+  min-width: 0;
+}
+
+.stepTitle {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--qs-text);
+  margin: 0.65rem 0 0.5rem;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  border: none !important;
+  padding-left: 0 !important;
+}
+
+.stepContent {
+  color: var(--qs-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.stepContent p {
+  margin: 0 0 0.75rem;
+}
+
+.stepContent a {
+  color: var(--qs-orange);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.stepContent a:hover {
+  text-decoration: underline;
+}
+
+.stepContent code {
+  font-size: 0.84rem;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: rgba(255, 87, 34, 0.07);
+  border: 1px solid rgba(255, 87, 34, 0.15);
+  color: var(--qs-text);
+  font-weight: 500;
+}
+
+/* ── Code blocks ── */
+.codeBlock {
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--qs-border);
+  margin: 0.5rem 0 0.75rem;
+  background: var(--qs-code-bg);
+}
+
+.codeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.codeLang {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.copyBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.copyBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.codeBlock pre {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  overflow-x: auto;
+  background: transparent !important;
+}
+
+.codeBlock code {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  color: var(--qs-code-text);
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+}
+
+/* ── Next Steps ── */
+.nextSection {
+  margin-top: 1rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--qs-border);
+}
+
+.nextTitle {
+  font-size: 1.35rem;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+  color: var(--qs-text);
+  margin: 0 0 1rem;
+  border: none !important;
+  padding-left: 0 !important;
+}
+
+.nextGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .nextGrid { grid-template-columns: 1fr; }
+}
+
+.nextCard {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 1rem 1.15rem;
+  border-radius: 12px;
+  background: var(--qs-surface);
+  border: 1px solid var(--qs-border);
+  text-decoration: none !important;
+  color: var(--qs-text);
+  transition: all 0.2s;
+}
+
+.nextCard:hover {
+  border-color: var(--qs-orange);
+  background: rgba(255, 87, 34, 0.03);
+  transform: translateY(-1px);
+}
+
+:global(.dark) .nextCard:hover {
+  background: rgba(255, 87, 34, 0.05);
+}
+
+.nextIcon {
+  font-size: 1.4rem;
+  flex-shrink: 0;
+}
+
+.nextCardTitle {
+  font-size: 0.9rem;
+  font-weight: 650;
+  color: var(--qs-text);
+  margin-bottom: 2px;
+}
+
+.nextCardDesc {
+  font-size: 0.8rem;
+  color: var(--qs-text-muted);
+  line-height: 1.4;
+}
+
+.nextArrow {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--qs-text-muted);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: all 0.2s;
+}
+
+.nextCard:hover .nextArrow {
+  opacity: 1;
+  transform: translateX(0);
+  color: var(--qs-orange);
+}

--- a/components/QuickStartSteps.tsx
+++ b/components/QuickStartSteps.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { useState } from 'react';
+import styles from './QuickStartSteps.module.css';
+
+interface Step {
+  number: number;
+  title: string;
+  content: React.ReactNode;
+}
+
+const steps: Step[] = [
+  {
+    number: 1,
+    title: 'Sign up for a Cardinal account',
+    content: (
+      <p>
+        Create your free account at{' '}
+        <a href="https://app.cardinalhq.io" target="_blank" rel="noopener noreferrer">
+          app.cardinalhq.io
+        </a>
+        .
+      </p>
+    ),
+  },
+  {
+    number: 2,
+    title: 'Download your Lakerunner Trial license',
+    content: <p>After signing in, download your trial license from the Cardinal dashboard.</p>,
+  },
+  {
+    number: 3,
+    title: 'Create the namespace',
+    content: (
+      <div className={styles.codeBlock}>
+        <div className={styles.codeHeader}>
+          <span className={styles.codeLang}>bash</span>
+          <CopyButton text="kubectl create namespace lakerunner" />
+        </div>
+        <pre>
+          <code>kubectl create namespace lakerunner</code>
+        </pre>
+      </div>
+    ),
+  },
+  {
+    number: 4,
+    title: 'Install using Helm',
+    content: (
+      <>
+        <p>
+          Use the{' '}
+          <a href="/lakerunner/install" target="_blank" rel="noopener noreferrer">
+            Installation Wizard
+          </a>{' '}
+          to generate a <code>values.yaml</code> tailored to your environment, then install:
+        </p>
+        <div className={styles.codeBlock}>
+          <div className={styles.codeHeader}>
+            <span className={styles.codeLang}>bash</span>
+            <CopyButton
+              text={`helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \\
+  --values values.yaml \\
+  --namespace lakerunner`}
+            />
+          </div>
+          <pre>
+            <code>{`helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \\
+  --values values.yaml \\
+  --namespace lakerunner`}</code>
+          </pre>
+        </div>
+      </>
+    ),
+  },
+  {
+    number: 5,
+    title: 'Verify the installation',
+    content: (
+      <>
+        <p>Wait for all pods to become ready:</p>
+        <div className={styles.codeBlock}>
+          <div className={styles.codeHeader}>
+            <span className={styles.codeLang}>bash</span>
+            <CopyButton text="kubectl get pods -n lakerunner -w" />
+          </div>
+          <pre>
+            <code>kubectl get pods -n lakerunner -w</code>
+          </pre>
+        </div>
+      </>
+    ),
+  },
+  {
+    number: 6,
+    title: 'Access Grafana',
+    content: (
+      <>
+        <p>Port-forward Grafana to your local machine:</p>
+        <div className={styles.codeBlock}>
+          <div className={styles.codeHeader}>
+            <span className={styles.codeLang}>bash</span>
+            <CopyButton text="kubectl port-forward -n lakerunner svc/grafana 3000:3000" />
+          </div>
+          <pre>
+            <code>kubectl port-forward -n lakerunner svc/grafana 3000:3000</code>
+          </pre>
+        </div>
+        <p>
+          Open{' '}
+          <a href="http://localhost:3000" target="_blank" rel="noopener noreferrer">
+            http://localhost:3000
+          </a>{' '}
+          in your browser. Lakerunner&apos;s data source is pre-configured.
+        </p>
+      </>
+    ),
+  },
+];
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button className={styles.copyBtn} onClick={handleCopy} aria-label="Copy to clipboard">
+      {copied ? (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+const nextSteps = [
+  {
+    icon: '🚀',
+    title: 'Production deployment',
+    description: 'Generate a production values.yaml with S3 and PostgreSQL',
+    href: '/lakerunner/install',
+  },
+  {
+    icon: '📐',
+    title: 'Sizing',
+    description: 'Estimate resource needs for your workload',
+    href: '/lakerunner/sizing',
+  },
+  {
+    icon: '🏗️',
+    title: 'Architecture',
+    description: 'Learn how ingestion, materialization, and query work',
+    href: '/lakerunner/architecture',
+  },
+  {
+    icon: '⌨️',
+    title: 'CLI Reference',
+    description: 'Manage your Lakerunner instance from the terminal',
+    href: '/lakerunner/cli',
+  },
+];
+
+export default function QuickStartSteps() {
+  return (
+    <div className={styles.wrapper}>
+      {/* Hero */}
+      <div className={styles.hero}>
+        <div className={styles.heroGlow} />
+        <div className={styles.heroBadge}>
+          <span className={styles.heroBadgeDot} />
+          Quick Start
+        </div>
+        <h2 className={styles.heroTitle}>Up and running in minutes</h2>
+        <p className={styles.heroSub}>
+          Get Lakerunner deployed on a local Kubernetes cluster — no cloud account required.
+        </p>
+      </div>
+
+      {/* Prerequisites */}
+      <div className={styles.prereqs}>
+        <h3 className={styles.prereqTitle}>Prerequisites</h3>
+        <div className={styles.prereqGrid}>
+          <div className={styles.prereqItem}>
+            <span className={styles.prereqIcon}>⎈</span>
+            <div>
+              <strong>Kubernetes 1.33+</strong>
+              <span className={styles.prereqAlt}>
+                or{' '}
+                <a href="https://kind.sigs.k8s.io/" target="_blank" rel="noopener noreferrer">
+                  kind
+                </a>
+                ,{' '}
+                <a href="https://minikube.sigs.k8s.io/" target="_blank" rel="noopener noreferrer">
+                  minikube
+                </a>
+                , etc.
+              </span>
+            </div>
+          </div>
+          <div className={styles.prereqItem}>
+            <span className={styles.prereqIcon}>⬡</span>
+            <div>
+              <strong>Helm 3.14+</strong>
+              <span className={styles.prereqAlt}>
+                <a href="https://helm.sh/docs/intro/install/" target="_blank" rel="noopener noreferrer">
+                  Install guide
+                </a>
+              </span>
+            </div>
+          </div>
+          <div className={styles.prereqItem}>
+            <span className={styles.prereqIcon}>▸</span>
+            <div>
+              <strong>kubectl</strong>
+              <span className={styles.prereqAlt}>
+                <a
+                  href="https://kubernetes.io/docs/tasks/tools/#kubectl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Install guide
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Steps */}
+      <div className={styles.timeline}>
+        {steps.map((step, i) => (
+          <div key={step.number} className={styles.step} style={{ animationDelay: `${i * 80}ms` }}>
+            <div className={styles.stepRail}>
+              <div className={styles.stepNumber}>{step.number}</div>
+              {i < steps.length - 1 && <div className={styles.stepLine} />}
+            </div>
+            <div className={styles.stepBody}>
+              <h3 className={styles.stepTitle}>{step.title}</h3>
+              <div className={styles.stepContent}>{step.content}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Next Steps */}
+      <div className={styles.nextSection}>
+        <h3 className={styles.nextTitle}>What&apos;s next?</h3>
+        <div className={styles.nextGrid}>
+          {nextSteps.map((item) => (
+            <a key={item.href} href={item.href} className={styles.nextCard}>
+              <span className={styles.nextIcon}>{item.icon}</span>
+              <div>
+                <div className={styles.nextCardTitle}>{item.title}</div>
+                <div className={styles.nextCardDesc}>{item.description}</div>
+              </div>
+              <svg
+                className={styles.nextArrow}
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/content/lakerunner/_meta.ts
+++ b/content/lakerunner/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: 'Overview',
+  quickstart: 'Quick Start',
   install: 'Installation Guide',
   sizing: 'Sizing Estimator',
   architecture: 'Architecture',

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -13,6 +13,14 @@ Get Lakerunner running on a local Kubernetes cluster in under 10 minutes.
 
 <Steps>
 
+{<h3>Sign up for a Cardinal account</h3>}
+
+Create your free account at <a href="https://app.cardinalhq.io" target="_blank">app.cardinalhq.io</a>.
+
+{<h3>Download your Lakerunner Trial license</h3>}
+
+After signing in, download your trial license from the Cardinal dashboard.
+
 {<h3>Create the namespace</h3>}
 
 ```bash copy

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -1,0 +1,75 @@
+import SupportCallout from '../../components/SupportCallout';
+
+# Quick Start
+
+Get Lakerunner running on a local Kubernetes cluster in under 10 minutes.
+
+## Prerequisites
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
+- [Helm](https://helm.sh/docs/intro/install/) 3.14+
+- A running Kubernetes cluster (e.g., [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), or [Docker Desktop](https://www.docker.com/products/docker-desktop/))
+
+## 1. Create a Namespace
+
+```bash copy
+kubectl create namespace lakerunner
+```
+
+## 2. Install Lakerunner
+
+```bash copy
+helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \
+  --namespace lakerunner
+```
+
+This installs Lakerunner with default settings suitable for local development and evaluation.
+
+## 3. Verify the Installation
+
+Wait for all pods to become ready:
+
+```bash copy
+kubectl get pods -n lakerunner -w
+```
+
+## 4. Access Grafana
+
+Port-forward Grafana to your local machine:
+
+```bash copy
+kubectl port-forward -n lakerunner svc/grafana 3000:3000
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser. Lakerunner's data source is pre-configured.
+
+## 5. Send Test Data
+
+Send a sample log entry using `curl`:
+
+```bash copy
+curl -X POST http://localhost:3100/loki/api/v1/push \
+  -H "Content-Type: application/json" \
+  -d '{"streams":[{"stream":{"app":"quickstart"},"values":[["'"$(date +%s)000000000"'","Hello from Lakerunner!"]]}]}'
+```
+
+> Lakerunner exposes a Loki-compatible push API, so any Loki client or agent (Promtail, Alloy, Fluent Bit) can ship data without changes.
+
+## 6. Query Your Logs
+
+In Grafana, go to **Explore** and run:
+
+```
+{app="quickstart"}
+```
+
+You should see the log entry you just sent.
+
+## Next Steps
+
+- **Production deployment** — Use the [Installation Wizard](/lakerunner/install) to generate a production `values.yaml` with S3, Kafka, and PostgreSQL configured
+- **Sizing** — Estimate resource needs with the [Sizing Estimator](/lakerunner/sizing)
+- **Architecture** — Learn how ingestion, materialization, and query work under the hood in the [Architecture](/lakerunner/architecture) section
+- **CLI** — Explore the [CLI Reference](/lakerunner/cli) for managing your Lakerunner instance
+
+<SupportCallout />

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -43,28 +43,6 @@ kubectl port-forward -n lakerunner svc/grafana 3000:3000
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. Lakerunner's data source is pre-configured.
 
-## 5. Send Test Data
-
-Send a sample log entry using `curl`:
-
-```bash copy
-curl -X POST http://localhost:3100/loki/api/v1/push \
-  -H "Content-Type: application/json" \
-  -d '{"streams":[{"stream":{"app":"quickstart"},"values":[["'"$(date +%s)000000000"'","Hello from Lakerunner!"]]}]}'
-```
-
-> Lakerunner exposes a Loki-compatible push API, so any Loki client or agent (Promtail, Alloy, Fluent Bit) can ship data without changes.
-
-## 6. Query Your Logs
-
-In Grafana, go to **Explore** and run:
-
-```
-{app="quickstart"}
-```
-
-You should see the log entry you just sent.
-
 ## Next Steps
 
 - **Production deployment** — Use the [Installation Wizard](/lakerunner/install) to generate a production `values.yaml` with S3, Kafka, and PostgreSQL configured

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -1,67 +1,8 @@
-import { Steps } from 'nextra/components';
+import QuickStartSteps from '../../components/QuickStartSteps';
 import SupportCallout from '../../components/SupportCallout';
 
 # Quick Start
 
-Get Lakerunner running on a local Kubernetes cluster in under 10 minutes.
-
-## Prerequisites
-
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
-- [Helm](https://helm.sh/docs/intro/install/) 3.14+
-- A Kubernetes cluster 1.33+ (or [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), etc.)
-
-<Steps>
-
-{<h3>Sign up for a Cardinal account</h3>}
-
-Create your free account at <a href="https://app.cardinalhq.io" target="_blank">app.cardinalhq.io</a>.
-
-{<h3>Download your Lakerunner Trial license</h3>}
-
-After signing in, download your trial license from the Cardinal dashboard.
-
-{<h3>Create the namespace</h3>}
-
-```bash copy
-kubectl create namespace lakerunner
-```
-
-{<h3>Install using Helm</h3>}
-
-Use the <a href="/lakerunner/install" target="_blank">Installation Wizard</a> to generate a `values.yaml` tailored to your environment, then install:
-
-```bash copy
-helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \
-  --values values.yaml \
-  --namespace lakerunner
-```
-
-{<h3>Verify the installation</h3>}
-
-Wait for all pods to become ready:
-
-```bash copy
-kubectl get pods -n lakerunner -w
-```
-
-{<h3>Access Grafana</h3>}
-
-Port-forward Grafana to your local machine:
-
-```bash copy
-kubectl port-forward -n lakerunner svc/grafana 3000:3000
-```
-
-Open [http://localhost:3000](http://localhost:3000) in your browser. Lakerunner's data source is pre-configured.
-
-</Steps>
-
-## Next Steps
-
-- **Production deployment** — Use the [Installation Wizard](/lakerunner/install) to generate a production `values.yaml` with S3 and PostgreSQL configured
-- **Sizing** — Estimate resource needs with the [Sizing Estimator](/lakerunner/sizing)
-- **Architecture** — Learn how ingestion, materialization, and query work under the hood in the [Architecture](/lakerunner/architecture) section
-- **CLI** — Explore the [CLI Reference](/lakerunner/cli) for managing your Lakerunner instance
+<QuickStartSteps />
 
 <SupportCallout />

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -21,7 +21,7 @@ kubectl create namespace lakerunner
 
 {<h3>Install using Helm</h3>}
 
-Use the [Installation Wizard](/lakerunner/install) to generate a `values.yaml` tailored to your environment, then install:
+Use the <a href="/lakerunner/install" target="_blank">Installation Wizard</a> to generate a `values.yaml` tailored to your environment, then install:
 
 ```bash copy
 helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -8,7 +8,7 @@ Get Lakerunner running on a local Kubernetes cluster in under 10 minutes.
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
 - [Helm](https://helm.sh/docs/intro/install/) 3.14+
-- A running Kubernetes cluster (e.g., [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), or [Docker Desktop](https://www.docker.com/products/docker-desktop/))
+- A Kubernetes cluster 1.33+ (or [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), etc.)
 
 ## 1. Create a Namespace
 

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -1,3 +1,4 @@
+import { Steps } from 'nextra/components';
 import SupportCallout from '../../components/SupportCallout';
 
 # Quick Start
@@ -10,22 +11,25 @@ Get Lakerunner running on a local Kubernetes cluster in under 10 minutes.
 - [Helm](https://helm.sh/docs/intro/install/) 3.14+
 - A Kubernetes cluster 1.33+ (or [kind](https://kind.sigs.k8s.io/), [minikube](https://minikube.sigs.k8s.io/), etc.)
 
-## 1. Create a Namespace
+<Steps>
+
+{<h3>Create the namespace</h3>}
 
 ```bash copy
 kubectl create namespace lakerunner
 ```
 
-## 2. Install Lakerunner
+{<h3>Install using Helm</h3>}
+
+Use the [Installation Wizard](/lakerunner/install) to generate a `values.yaml` tailored to your environment, then install:
 
 ```bash copy
 helm install lakerunner oci://public.ecr.aws/cardinalhq.io/lakerunner \
+  --values values.yaml \
   --namespace lakerunner
 ```
 
-This installs Lakerunner with default settings suitable for local development and evaluation.
-
-## 3. Verify the Installation
+{<h3>Verify the installation</h3>}
 
 Wait for all pods to become ready:
 
@@ -33,7 +37,7 @@ Wait for all pods to become ready:
 kubectl get pods -n lakerunner -w
 ```
 
-## 4. Access Grafana
+{<h3>Access Grafana</h3>}
 
 Port-forward Grafana to your local machine:
 
@@ -42,6 +46,8 @@ kubectl port-forward -n lakerunner svc/grafana 3000:3000
 ```
 
 Open [http://localhost:3000](http://localhost:3000) in your browser. Lakerunner's data source is pre-configured.
+
+</Steps>
 
 ## Next Steps
 

--- a/content/lakerunner/quickstart.mdx
+++ b/content/lakerunner/quickstart.mdx
@@ -51,7 +51,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser. Lakerunner'
 
 ## Next Steps
 
-- **Production deployment** — Use the [Installation Wizard](/lakerunner/install) to generate a production `values.yaml` with S3, Kafka, and PostgreSQL configured
+- **Production deployment** — Use the [Installation Wizard](/lakerunner/install) to generate a production `values.yaml` with S3 and PostgreSQL configured
 - **Sizing** — Estimate resource needs with the [Sizing Estimator](/lakerunner/sizing)
 - **Architecture** — Learn how ingestion, materialization, and query work under the hood in the [Architecture](/lakerunner/architecture) section
 - **CLI** — Explore the [CLI Reference](/lakerunner/cli) for managing your Lakerunner instance

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -51,3 +51,16 @@ article code {
 article ::selection {
   background: var(--cardinal-accent-soft);
 }
+
+.nextra-steps h2:before,
+.nextra-steps h3:not([style^='visibility:']):before,
+.nextra-steps h4:before,
+.nextra-steps h5:before,
+.nextra-steps h6:before {
+  --size: 56px;
+  width: var(--size) !important;
+  height: var(--size) !important;
+  font-size: 1.5rem !important;
+  line-height: calc(var(--size) - 8px) !important;
+  margin-inline-start: calc(-1 * var(--size) - 8px) !important;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -52,6 +52,11 @@ article ::selection {
   background: var(--cardinal-accent-soft);
 }
 
+.nextra-steps {
+  padding-inline-start: 3.5rem !important;
+  margin-inline-start: 1.5rem !important;
+}
+
 .nextra-steps h2:before,
 .nextra-steps h3:not([style^='visibility:']):before,
 .nextra-steps h4:before,
@@ -62,5 +67,5 @@ article ::selection {
   height: var(--size) !important;
   font-size: 1.5rem !important;
   line-height: calc(var(--size) - 8px) !important;
-  margin-inline-start: calc(-1 * var(--size) - 8px) !important;
+  margin-inline-start: calc(-1 * var(--size) - 14px) !important;
 }


### PR DESCRIPTION
## Summary
- Adds a new Quick Start page under Lakerunner that walks users through a local deployment in under 10 minutes
- Covers namespace creation, Helm install, Grafana access, sending test data via the Loki-compatible API, and querying logs
- Placed in nav between Overview and Installation Guide

## Test plan
- [x] `pnpm build` succeeds (50 pages generated)
- [x] `pnpm test` passes (62/62)
- [ ] Verify page renders correctly on dev server
- [ ] Confirm nav ordering: Overview → Quick Start → Installation Guide