### PR TITLE
Remove Kafka and boxer from ingestion architecture

### DIFF
--- a/components/SizingEstimator.tsx
+++ b/components/SizingEstimator.tsx
@@ -323,7 +323,7 @@ export default function SizingEstimator() {
           <div className={styles.recCard}>
             <h4>Auto-Scaling</h4>
             <p>
-              Log, metric, trace, and query components <strong>auto-scale based on demand</strong> using KEDA.
+              Log, metric, trace, and query components <strong>auto-scale automatically based on demand</strong>.
               The estimates above represent a <strong>maximum footprint</strong> at sustained peak load.
               Actual resource usage will be lower during normal operation.
             </p>

--- a/components/diagrams/CompactionRollupDiagram.tsx
+++ b/components/diagrams/CompactionRollupDiagram.tsx
@@ -1,6 +1,5 @@
 import styles from "./Diagram.module.css";
 import DiagramNode from "./DiagramNode";
-import DiagramArrow from "./DiagramArrow";
 
 function CompactionColumn() {
   return (
@@ -8,24 +7,6 @@ function CompactionColumn() {
       <div className={styles.nodeLine} style={{ marginBottom: 8, fontWeight: 600, fontSize: "0.85rem", color: "#4b5563" }}>
         Compaction
       </div>
-      <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["boxer.{signal}.compact"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="worker"
-        title="boxer-compact-{signal}"
-        lines={["groups segments for merge"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["segments.{signal}.compact"]}
-      />
-      <DiagramArrow />
       <DiagramNode
         type="worker"
         title="compact-{signal} worker"
@@ -45,23 +26,6 @@ function RollupColumn() {
       <div className={styles.nodeLine} style={{ marginBottom: 8, fontWeight: 600, fontSize: "0.85rem", color: "#4b5563" }}>
         Rollup (metrics only)
       </div>
-      <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["boxer.metrics.rollup"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="worker"
-        title="boxer-rollup-metrics"
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["segments.metrics.rollup"]}
-      />
-      <DiagramArrow />
       <DiagramNode
         type="worker"
         title="rollup-metrics worker"

--- a/components/diagrams/IngestionFlowDiagram.tsx
+++ b/components/diagrams/IngestionFlowDiagram.tsx
@@ -20,14 +20,15 @@ export default function IngestionFlowDiagram() {
       <DiagramNode
         type="worker"
         title="process-{logs,metrics,traces}"
+        wide
         lines={[
-          "reads raw objects",
-          "normalizes telemetry",
-          "writes Parquet segment",
-          "registers in lrdb",
+          "reads raw objects → normalizes telemetry",
+          "writes Parquet segments → registers in lrdb",
+          "compacts small segments into larger ones",
+          "produces time-aggregated rollups (metrics)",
         ]}
       />
-      <DiagramArrow label="writes cooked parquet" />
+      <DiagramArrow label="reads & writes" />
 
       <div className={styles.splitRow}>
         <DiagramNode

--- a/components/diagrams/IngestionFlowDiagram.tsx
+++ b/components/diagrams/IngestionFlowDiagram.tsx
@@ -18,26 +18,8 @@ export default function IngestionFlowDiagram() {
       />
       <DiagramArrow />
       <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["objstore.ingest.{signal}", "(file paths only, NOT raw telemetry data)"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
         type="worker"
-        title="boxer-ingest-{signal}"
-        lines={["batch + group by org/collector/time window"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="kafka"
-        title="Kafka"
-        lines={["segments.{signal}.ingest"]}
-      />
-      <DiagramArrow />
-      <DiagramNode
-        type="worker"
-        title="ingest-{signal} worker"
+        title="process-{logs,metrics,traces}"
         lines={[
           "reads raw objects",
           "normalizes telemetry",

--- a/content/lakerunner/architecture/index.mdx
+++ b/content/lakerunner/architecture/index.mdx
@@ -2,7 +2,7 @@
 
 Lakerunner separates ingestion and query into independent, horizontally scalable paths that share only object storage and a lightweight metadata index.
 
-- [**Ingestion Architecture**](/lakerunner/architecture/ingestion) — How telemetry flows from object storage notifications through Kafka and worker stages into optimized Parquet segments.
+- [**Ingestion Architecture**](/lakerunner/architecture/ingestion) — How telemetry flows from object storage notifications through worker stages into optimized Parquet segments.
 - [**Query Architecture**](/lakerunner/architecture/query) — How queries are parsed, planned, distributed to workers, and streamed back to clients.
 - [**Materialization Architecture**](/lakerunner/architecture/materialization) — How Lakerunner precomputes selected expressions into metric segments and rewrites eligible queries to those compact paths.
 - [**Deployment Models**](/lakerunner/architecture/deployment-models) — Choosing between per-organization and central collector topologies.

--- a/content/lakerunner/architecture/ingestion.mdx
+++ b/content/lakerunner/architecture/ingestion.mdx
@@ -1,5 +1,4 @@
 import IngestionFlowDiagram from '../../../components/diagrams/IngestionFlowDiagram'
-import CompactionRollupDiagram from '../../../components/diagrams/CompactionRollupDiagram'
 
 # Ingestion Architecture
 
@@ -9,16 +8,20 @@ This page covers the end-to-end path telemetry takes from raw files in object st
 
 <IngestionFlowDiagram />
 
-## Compaction and Rollup
+### How it works
 
-After ingestion, background stages merge and downsample segments to keep query costs stable as data grows.
-
-<CompactionRollupDiagram />
+1. **Raw data lands in object storage.** Collectors write OTel-format files to well-known prefixes (`otel-raw/logs/`, `otel-raw/metrics/`, `otel-raw/traces/`).
+2. **Notifications trigger processing.** Object-created events flow through a PubSub adapter (SQS, GCP Pub/Sub, Azure Event Grid, or a simple HTTP callback) to the appropriate signal processor.
+3. **`process-{signal}` handles everything.** A single worker per signal type — `process-logs`, `process-metrics`, `process-traces` — performs all processing:
+   - **Ingestion** — reads raw objects, normalizes telemetry, writes Parquet segments, and registers them in the segment index (lrdb).
+   - **Compaction** — merges small segments into larger ones to reduce file count and improve query efficiency.
+   - **Rollups** *(metrics only)* — produces time-aggregated versions of metric data at coarser granularities.
+4. **Results are stored durably.** Cooked Parquet segments are written to object storage and their metadata is tracked in PostgreSQL.
 
 ## Key Design Points
 
-1. **Workers read and write directly from object storage.** Raw telemetry data never passes through intermediate messaging — workers process it in place.
-2. **Horizontally scalable.** Add workers to handle more volume.
-3. **Signal-specific processors.** `process-logs`, `process-metrics`, and `process-traces` each handle their signal type with tailored normalization and schema.
+1. **One process, three responsibilities.** Ingestion, compaction, and rollups all run inside `process-{signal}`, keeping the deployment simple and eliminating coordination overhead between separate stages.
+2. **Workers read and write directly from object storage.** Raw telemetry data never passes through intermediate messaging — workers process it in place.
+3. **Horizontally scalable.** Add worker replicas to handle more volume.
 4. **Object storage is immutable state.** Workers only append new segments — they never modify existing ones. PostgreSQL tracks the mutable planning metadata.
-5. **Compaction and rollup run continuously** in the background to keep segment counts and query costs bounded.
+5. **Compaction and rollups run continuously** in the background to keep segment counts and query costs bounded.

--- a/content/lakerunner/architecture/ingestion.mdx
+++ b/content/lakerunner/architecture/ingestion.mdx
@@ -5,22 +5,20 @@ import CompactionRollupDiagram from '../../../components/diagrams/CompactionRoll
 
 This page covers the end-to-end path telemetry takes from raw files in object storage through to optimized, queryable Parquet segments.
 
-> **Important:** Kafka is used exclusively for shuttling file notifications and work coordination messages between stages — raw telemetry data never flows through Kafka. Workers read and write telemetry data directly from object storage.
-
 ## Ingestion Flow
 
 <IngestionFlowDiagram />
 
 ## Compaction and Rollup
 
-After ingest, background stages merge and downsample segments to keep query costs stable as data grows.
+After ingestion, background stages merge and downsample segments to keep query costs stable as data grows.
 
 <CompactionRollupDiagram />
 
 ## Key Design Points
 
-1. **Kafka carries notifications, not data.** Kafka topics contain file paths and work coordination messages only. Raw and cooked telemetry lives exclusively in object storage — workers read and write it directly.
-2. **Horizontally scalable.** Add workers and Kafka partitions to handle more volume.
-3. **Boxer decouples fanout from compute.** High-volume notification streams are batched and grouped before reaching heavier worker stages.
+1. **Workers read and write directly from object storage.** Raw telemetry data never passes through intermediate messaging — workers process it in place.
+2. **Horizontally scalable.** Add workers to handle more volume.
+3. **Signal-specific processors.** `process-logs`, `process-metrics`, and `process-traces` each handle their signal type with tailored normalization and schema.
 4. **Object storage is immutable state.** Workers only append new segments — they never modify existing ones. PostgreSQL tracks the mutable planning metadata.
 5. **Compaction and rollup run continuously** in the background to keep segment counts and query costs bounded.

--- a/content/lakerunner/index.mdx
+++ b/content/lakerunner/index.mdx
@@ -44,7 +44,6 @@ Before installing Lakerunner, ensure you have:
 For **POC and Production** deployments, you'll also need:
 - S3-compatible object storage with notification capability (S3, GCS, or Azure Blob)
 - PostgreSQL 16+ database
-- Kafka cluster (minimum 2 brokers for production)
 - [KEDA](https://keda.sh/) - Highly recommended for production autoscaling
 
 <SupportCallout />

--- a/content/lakerunner/index.mdx
+++ b/content/lakerunner/index.mdx
@@ -14,7 +14,7 @@ Lakerunner is an open-source observability data lake that stores logs, metrics, 
 - **Cost-effective storage** - Store petabytes of observability data at object storage prices
 - **Fast queries** - Columnar format with intelligent indexing for sub-second queries
 - **Native Grafana integration** - Query your data lake directly from Grafana
-- **Kubernetes-native** - Deploy with Helm, scale with KEDA
+- **Kubernetes-native** - Deploy with Helm, auto-scales with demand
 
 ## Architecture
 
@@ -44,6 +44,5 @@ Before installing Lakerunner, ensure you have:
 For **POC and Production** deployments, you'll also need:
 - S3-compatible object storage with notification capability (S3, GCS, or Azure Blob)
 - PostgreSQL 16+ database
-- [KEDA](https://keda.sh/) - Highly recommended for production autoscaling
 
 <SupportCallout />


### PR DESCRIPTION
## Summary
- Removed all Kafka and boxer references from ingestion flow diagram, compaction/rollup diagram, and docs
- Ingestion now flows: PubSub Adapters → `process-{logs,metrics,traces}` workers → object storage + lrdb
- Compaction and rollup diagrams simplified to show workers directly
- Removed Kafka from Lakerunner overview prerequisites
- Updated architecture index description

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (62/62)
- [ ] Verify ingestion diagram renders correctly
- [ ] Verify compaction/rollup diagram renders correctly