### PR TITLE
Add OTel Collectors and Demo App guides to Quick Start

### DIFF
--- a/components/QuickStartSteps.tsx
+++ b/components/QuickStartSteps.tsx
@@ -96,7 +96,7 @@ const steps: Step[] = [
     title: 'Access Grafana',
     content: (
       <>
-        <p>Port-forward Grafana to your local machine:</p>
+        <p>If Grafana was included in your installation, port-forward it to your local machine:</p>
         <div className={styles.codeBlock}>
           <div className={styles.codeHeader}>
             <span className={styles.codeLang}>bash</span>
@@ -111,7 +111,29 @@ const steps: Step[] = [
           <a href="http://localhost:3000" target="_blank" rel="noopener noreferrer">
             http://localhost:3000
           </a>{' '}
-          in your browser. Lakerunner&apos;s data source is pre-configured.
+          in your browser. Lakerunner&apos;s data source is pre-configured, but you won&apos;t see any data yet — that comes in the next step.
+        </p>
+      </>
+    ),
+  },
+  {
+    number: 7,
+    title: 'Send data',
+    content: (
+      <>
+        <p>
+          Install{' '}
+          <a href="/lakerunner/collectors" target="_blank" rel="noopener noreferrer">
+            OpenTelemetry Collectors
+          </a>{' '}
+          to monitor your cluster and write telemetry to S3.
+        </p>
+        <p>
+          Generate data from your real applications, or use the{' '}
+          <a href="/lakerunner/otel-demo" target="_blank" rel="noopener noreferrer">
+            OTel Demo Application
+          </a>{' '}
+          to produce realistic logs, metrics, and traces right away.
         </p>
       </>
     ),

--- a/components/QuickStartSteps.tsx
+++ b/components/QuickStartSteps.tsx
@@ -145,28 +145,28 @@ function CopyButton({ text }: { text: string }) {
 
 const nextSteps = [
   {
+    icon: '📡',
+    title: 'Install OpenTelemetry Collectors',
+    description: 'Deploy the agent, poller, and gateway to monitor your cluster and write to S3',
+    href: '/lakerunner/collectors',
+  },
+  {
+    icon: '🛍️',
+    title: 'Install the OTel Demo Application',
+    description: 'Deploy a microservices e-commerce app that generates realistic telemetry',
+    href: '/lakerunner/otel-demo',
+  },
+  {
     icon: '🚀',
     title: 'Production deployment',
     description: 'Generate a production values.yaml with S3 and PostgreSQL',
     href: '/lakerunner/install',
   },
   {
-    icon: '📐',
-    title: 'Sizing',
-    description: 'Estimate resource needs for your workload',
-    href: '/lakerunner/sizing',
-  },
-  {
     icon: '🏗️',
     title: 'Architecture',
     description: 'Learn how ingestion, materialization, and query work',
     href: '/lakerunner/architecture',
-  },
-  {
-    icon: '⌨️',
-    title: 'CLI Reference',
-    description: 'Manage your Lakerunner instance from the terminal',
-    href: '/lakerunner/cli',
   },
 ];
 

--- a/content/lakerunner/_meta.ts
+++ b/content/lakerunner/_meta.ts
@@ -2,6 +2,8 @@ export default {
   index: 'Overview',
   quickstart: 'Quick Start',
   install: 'Installation Guide',
+  collectors: 'OpenTelemetry Collectors',
+  'otel-demo': 'OTel Demo Application',
   sizing: 'Sizing Estimator',
   architecture: 'Architecture',
   cli: 'CLI Reference',

--- a/content/lakerunner/collectors.mdx
+++ b/content/lakerunner/collectors.mdx
@@ -1,0 +1,267 @@
+import SupportCallout from '../../components/SupportCallout';
+
+# OpenTelemetry Collectors
+
+Lakerunner ingests telemetry from [OpenTelemetry Collectors](https://opentelemetry.io/docs/collector/) that write data to your S3-compatible object storage bucket. This guide covers the recommended three-tier collector architecture for monitoring Kubernetes clusters.
+
+## Architecture Overview
+
+The collector stack uses three components, each with a distinct role:
+
+| Component | Deployment | Purpose |
+|-----------|-----------|---------|
+| **Agent** | DaemonSet (one per node) | Receives OTLP from workloads, scrapes kubelet stats, enriches with Kubernetes attributes, forwards to gateway |
+| **Poller** | Deployment (single replica) | Watches cluster-level Kubernetes objects (pods, nodes, deployments, HPAs) and emits cluster metrics |
+| **Gateway** | Deployment (2+ replicas) | Aggregates data from agents and pollers, generates service graph metrics from traces, exports to S3 |
+
+```
+Workloads (OTLP)          External OTLP
+    │                         │
+    ▼                         ▼
+┌──────────┐  ┌──────────┐  ┌──────────────┐
+│  Agent   │  │  Poller  │  │              │
+│ (per     │  │ (1x)     │──│   Gateway    │──► S3 Bucket
+│  node)   │──│          │  │   (2x)       │
+└──────────┘  └──────────┘  └──────────────┘
+```
+
+## Agent
+
+The agent runs as a DaemonSet on every node with `hostNetwork: true`. It:
+
+- **Receives OTLP** on ports 4317 (gRPC) and 4318 (HTTP) from workloads on the same node
+- **Scrapes kubelet stats** every 10 seconds for node, pod, container, and volume metrics
+- **Enriches all telemetry** with Kubernetes attributes (pod name, namespace, deployment, labels, etc.)
+- **Sets `service.name`** from the owning controller (deployment, daemonset, statefulset, cronjob, or job)
+- **Converts cumulative metrics to delta** before forwarding to the gateway
+- **Forwards** all data to the gateway over internal OTLP/HTTP (port 24318)
+
+### Agent Configuration
+
+```yaml copy
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+  kubeletstats:
+    auth_type: serviceAccount
+    collection_interval: 10s
+    endpoint: "${env:HOST_IP}:10250"
+    insecure_skip_verify: true
+    node: "${env:K8S_NODE_NAME}"
+    metric_groups: [node, pod, container, volume]
+
+processors:
+  k8sattributes:
+    extract:
+      labels:
+        - from: pod
+          key_regex: "(.*)"
+          tag_name: "$1"
+      metadata:
+        - k8s.node.name
+        - k8s.namespace.name
+        - k8s.deployment.name
+        - k8s.replicaset.name
+        - k8s.daemonset.name
+        - k8s.statefulset.name
+        - k8s.cronjob.name
+        - k8s.job.name
+        - k8s.pod.name
+        - k8s.pod.ip
+        - k8s.container.name
+        - container.id
+        - container.image.name
+        - container.image.tag
+    filter:
+      node_from_env_var: K8S_NODE_NAME
+    pod_association:
+      - sources: [{ from: connection }]
+      - sources: [{ from: resource_attribute, name: k8s.pod.uid }]
+      - sources: [{ from: resource_attribute, name: k8s.pod.ip }]
+  resource/core:
+    attributes:
+      - { action: upsert, from_attribute: k8s.deployment.name, key: service.name }
+      - { action: upsert, from_attribute: k8s.daemonset.name, key: service.name }
+      - { action: upsert, from_attribute: k8s.statefulset.name, key: service.name }
+      - { action: upsert, from_attribute: k8s.cronjob.name, key: service.name }
+      - { action: upsert, from_attribute: k8s.job.name, key: service.name }
+      - { action: upsert, key: k8s.cluster.name, value: "${env:K8S_CLUSTER_NAME}" }
+  cumulativetodelta:
+    max_staleness: 15m
+  batch:
+    send_batch_max_size: 30000
+    send_batch_size: 10000
+    timeout: 10s
+
+exporters:
+  otlphttp/upstream:
+    endpoint: "http://collector-gateway-interproc:24318"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [k8sattributes, resource/core, batch]
+      exporters: [otlphttp/upstream]
+    metrics:
+      receivers: [otlp, kubeletstats]
+      processors: [k8sattributes, resource/core, cumulativetodelta, batch]
+      exporters: [otlphttp/upstream]
+    traces:
+      receivers: [otlp]
+      processors: [k8sattributes, resource/core, batch]
+      exporters: [otlphttp/upstream]
+```
+
+### Agent Resources
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| CPU | 1 | 1 |
+| Memory | 500Mi | 500Mi |
+
+## Poller
+
+The poller is a single-replica deployment that watches cluster-level Kubernetes objects and emits metrics about their state. It monitors:
+
+- **Node conditions**: Ready, MemoryPressure, DiskPressure, PIDPressure
+- **Allocatable resources**: CPU, memory, ephemeral-storage, storage
+- **Object counts**: Pods, deployments, daemonsets, statefulsets, jobs, HPAs, and more
+
+### Poller Configuration
+
+```yaml copy
+receivers:
+  k8s_cluster:
+    auth_type: serviceAccount
+    node_conditions_to_report: [Ready, MemoryPressure, DiskPressure, PIDPressure]
+    allocatable_types_to_report: [cpu, memory, ephemeral-storage, storage]
+
+processors:
+  resource/core:
+    attributes:
+      - { action: upsert, key: k8s.cluster.name, value: "${env:K8S_CLUSTER_NAME}" }
+  cumulativetodelta:
+    max_staleness: 15m
+  batch:
+    send_batch_max_size: 30000
+    send_batch_size: 10000
+    timeout: 10s
+
+exporters:
+  otlphttp/upstream:
+    endpoint: "http://collector-gateway-interproc:24318"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [k8s_cluster]
+      processors: [resource/core, cumulativetodelta, batch]
+      exporters: [otlphttp/upstream]
+```
+
+### Poller Resources
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| CPU | 1 | 1 |
+| Memory | 500Mi | 500Mi |
+
+## Gateway
+
+The gateway is the central aggregation point. It receives data from agents and pollers on an internal port, and can also accept external OTLP data directly. All data is exported to your S3 bucket.
+
+Key features:
+- **Service graph generation** — Extracts span-derived metrics (call counts, latency) from traces, grouped by `k8s.cluster.name` and `k8s.namespace.name`
+- **Load-balanced metric aggregation** — External cumulative metrics are load-balanced across gateway pods by stream ID before delta conversion
+- **S3 export** — Writes all telemetry to S3 under `otel-raw/{org_id}/{cluster_name}/`
+
+### Gateway Configuration
+
+```yaml copy
+connectors:
+  servicegraph:
+    dimensions: [k8s.cluster.name, k8s.namespace.name]
+    metrics_flush_interval: 10s
+    store:
+      ttl: 10s
+
+receivers:
+  otlp/interproc:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:24318
+  otlp/external:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  awss3:
+    marshaler: otlp_proto
+    s3uploader:
+      compression: gzip
+      endpoint: "${env:AWS_S3_ENDPOINT}"
+      region: "${env:AWS_REGION}"
+      s3_bucket: "${env:AWS_S3_BUCKET}"
+      s3_prefix: "otel-raw/${env:LAKERUNNER_ORGANIZATION_ID}/${env:K8S_CLUSTER_NAME}"
+
+processors:
+  cumulativetodelta:
+    max_staleness: 15m
+  batch:
+    send_batch_max_size: 30000
+    send_batch_size: 10000
+    timeout: 10s
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp/interproc]
+      processors: [batch]
+      exporters: [awss3]
+    metrics:
+      receivers: [otlp/interproc]
+      processors: [batch]
+      exporters: [awss3]
+    traces:
+      receivers: [otlp/interproc]
+      processors: [batch]
+      exporters: [servicegraph, awss3]
+    metrics/servicegraph:
+      receivers: [servicegraph]
+      processors: [cumulativetodelta, batch]
+      exporters: [awss3]
+```
+
+### Gateway Resources
+
+| Resource | Request | Limit |
+|----------|---------|-------|
+| CPU | 2 | 2 |
+| Memory | 2Gi | 2Gi |
+
+## Deploying
+
+The collector manifests are designed to be deployed with [Kustomize](https://kustomize.io/). Before deploying, you need to:
+
+1. **Create the `collector` namespace**
+2. **Set your AWS credentials** in the gateway secrets
+3. **Set environment variables** for `K8S_CLUSTER_NAME`, `AWS_S3_BUCKET`, `AWS_REGION`, and `LAKERUNNER_ORGANIZATION_ID`
+
+```bash copy
+kubectl create namespace collector
+kubectl apply -k base-collector-manifests/
+```
+
+<SupportCallout />

--- a/content/lakerunner/otel-demo.mdx
+++ b/content/lakerunner/otel-demo.mdx
@@ -1,0 +1,192 @@
+import SupportCallout from '../../components/SupportCallout';
+
+# OpenTelemetry Demo Application
+
+The [OpenTelemetry Demo](https://opentelemetry.io/docs/demo/) is a microservices-based e-commerce application that generates realistic logs, metrics, and traces. It's a great way to see Lakerunner in action with real-world telemetry.
+
+## What You Get
+
+The demo deploys a full e-commerce application with services written in multiple languages (Go, Java, Python, Node.js, .NET, and more). Each service is instrumented with OpenTelemetry and generates:
+
+- **Logs** from application output
+- **Metrics** from runtime instrumentation and kubelet stats
+- **Traces** spanning the full request lifecycle across services
+
+## Prerequisites
+
+- A running Lakerunner installation (see the [Quick Start](/lakerunner/quickstart))
+- [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) or `kubectl` with built-in kustomize support
+- A Cardinal API key (from your [Cardinal dashboard](https://app.cardinalhq.io))
+
+## Installation
+
+### 1. Create the namespace
+
+```bash copy
+kubectl create namespace otel-demo
+```
+
+### 2. Create the Helm values file
+
+Create a `values.yaml` that configures the demo to export telemetry to your Cardinal endpoint:
+
+```yaml copy
+default:
+  envOverrides:
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "10000"
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.namespace.name=otel-demo,k8s.cluster.name=YOUR_CLUSTER_NAME"
+
+opentelemetry-collector:
+  config:
+    exporters:
+      otlphttp/cardinal:
+        endpoint: https://otelhttp.intake.YOUR_REGION.aws.cardinalhq.io
+        headers:
+          x-cardinalhq-api-key: YOUR_API_KEY
+    service:
+      pipelines:
+        traces:
+          exporters: [otlphttp/cardinal, spanmetrics]
+        metrics:
+          exporters: [otlphttp/cardinal]
+        logs:
+          exporters: [otlphttp/cardinal]
+
+# Disable built-in observability backends — Lakerunner replaces them
+jaeger:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+opensearch:
+  enabled: false
+```
+
+Replace `YOUR_CLUSTER_NAME`, `YOUR_REGION`, and `YOUR_API_KEY` with your actual values.
+
+### 3. Install with Helm
+
+```bash copy
+helm install otel-demo opentelemetry-demo \
+  --repo https://open-telemetry.github.io/opentelemetry-helm-charts \
+  --version 0.38.6 \
+  --namespace otel-demo \
+  --values values.yaml
+```
+
+### 4. Add kubelet stats collection (optional)
+
+To also collect node-level metrics from the demo cluster, deploy a lightweight kubelet stats collector:
+
+```yaml copy
+# kubeletstats-collector-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeletstats-collector
+  namespace: otel-demo
+data:
+  config.yaml: |
+    receivers:
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: https://${env:NODE_IP}:10250
+        insecure_skip_verify: true
+        metric_groups: [node, pod, container]
+
+    processors:
+      k8sattributes:
+        passthrough: false
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.uid
+        extract:
+          labels:
+            - tag_name: service.name
+              key: opentelemetry.io/name
+              from: pod
+      resource:
+        attributes:
+          - key: k8s.cluster.name
+            value: YOUR_CLUSTER_NAME
+            action: upsert
+      batch: {}
+
+    exporters:
+      otlphttp/cardinal:
+        endpoint: https://otelhttp.intake.YOUR_REGION.aws.cardinalhq.io
+        headers:
+          x-cardinalhq-api-key: ${env:CARDINAL_API_KEY}
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [kubeletstats]
+          processors: [k8sattributes, resource, batch]
+          exporters: [otlphttp/cardinal]
+```
+
+Deploy the collector as a DaemonSet:
+
+```yaml copy
+# kubeletstats-collector-daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubeletstats-collector
+  namespace: otel-demo
+spec:
+  selector:
+    matchLabels:
+      app: kubeletstats-collector
+  template:
+    metadata:
+      labels:
+        app: kubeletstats-collector
+    spec:
+      serviceAccountName: kubeletstats-collector
+      containers:
+        - name: collector
+          image: otel/opentelemetry-collector-contrib:0.146.1
+          args: ["--config=/etc/otelcol/config.yaml"]
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: CARDINAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kubeletstats-collector
+                  key: api-key
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: kubeletstats-collector
+```
+
+### 5. Verify in Grafana
+
+Open Grafana (see [Quick Start step 6](/lakerunner/quickstart)) and navigate to **Explore**. You should see:
+
+- **Logs** from the demo services
+- **Metrics** including application metrics and kubelet stats
+- **Traces** spanning the full request lifecycle across services
+
+<SupportCallout />


### PR DESCRIPTION
## Summary
- **New page: OpenTelemetry Collectors** (`/lakerunner/collectors`) — Documents the three-tier agent/poller/gateway collector architecture with full configuration examples based on our `base-collector-manifests`
- **New page: OTel Demo Application** (`/lakerunner/otel-demo`) — Step-by-step guide to deploy the official OTel demo app with Cardinal integration, including optional kubelet stats collection
- **Updated Quick Start next steps** — Prioritizes "Install Collectors" and "Install OTel Demo" as the first two cards after setup

## Test plan
- [x] `pnpm build` succeeds (pages indexed)
- [x] `pnpm test` passes (62/62)
- [ ] Verify new pages render correctly
- [ ] Verify Quick Start next steps cards link correctly