### PR TITLE
docs(maestro): add install guide

### DIFF
--- a/content/_meta.ts
+++ b/content/_meta.ts
@@ -1,5 +1,5 @@
 export default {
   index: 'Welcome',
-  maestro: 'Product',
+  maestro: 'Maestro',
   lakerunner: 'Lakerunner',
 }

--- a/content/maestro/_meta.ts
+++ b/content/maestro/_meta.ts
@@ -3,5 +3,6 @@ export default {
     title: 'Overview',
     display: 'hidden',
   },
+  install: 'Installation',
   integrations: 'Integrations',
 }

--- a/content/maestro/index.mdx
+++ b/content/maestro/index.mdx
@@ -1,35 +1,21 @@
-# Product
+# Maestro
 
-Cardinal is an AI-powered observability and incident management platform. It is powered by Maestro, an independently deployable agent server.
+Maestro is Cardinal's AI agent for observability. It turns natural-language questions into plans, executes them against your telemetry and operational systems, and answers with real data — not guesses.
+
+## What it does
+
+- **Explore your observability data.** Maestro drives [Lakerunner](/lakerunner) as a first-class data source. Ask about logs, metrics, services, or time ranges in plain English and Maestro figures out which queries to run, runs them, and summarizes the result.
+- **Investigate incidents agentically.** Maestro plans multi-step investigations: pull recent errors, correlate with a deploy, check downstream dependencies, open a ticket. You watch the plan unfold rather than stringing the steps together yourself.
+- **Act on what it finds.** With the right integrations connected, Maestro can open GitHub PRs, file ServiceNow incidents, or notify Slack / Teams / PagerDuty.
+
+## How it works
+
+Maestro is built on Cardinal's Orchestra planning engine. Every request goes through **plan → execute → evaluate**: it picks the right tools, executes them with retries and rate-limit handling, and evaluates the result before responding. Tools come from connected integrations exposed over the Model Context Protocol.
+
+## Installation
+
+Self-hosting Maestro? Start with the [Installation guide](/maestro/install) — Helm chart, environment variables, OIDC, AWS Bedrock on EKS, and first-login walkthrough.
 
 ## Integrations
 
-Integrations connect Cardinal to your external services and data sources. Once configured, the AI agent can query, explore, and act on data from these systems through natural language.
-
-Cardinal supports three categories of integrations:
-
-### Data Sources
-
-Connect databases and observability platforms so the AI agent can explore schemas, run queries, and surface insights.
-
-- [Lakerunner](/maestro/integrations/lakerunner) — Logs, metrics, and alerting
-- [PostgreSQL](/maestro/integrations/postgres) — Relational databases
-- [Google BigQuery](/maestro/integrations/bigquery) — Cloud data warehouse
-- [Snowflake](/maestro/integrations/snowflake) — Cloud data warehouse
-- [Amazon Athena](/maestro/integrations/athena) — S3 data lake queries
-- [ClickHouse](/maestro/integrations/clickhouse) — Columnar analytics database
-
-### Service Integrations
-
-Connect platforms the AI agent can interact with to search, query, and perform actions.
-
-- [GitHub](/maestro/integrations/github) — Code search, PRs, issues, and deployments
-- [ServiceNow](/maestro/integrations/servicenow) — ITSM: incidents, changes, CMDB, and knowledge
-
-### Notifications
-
-Send alerts and messages to communication channels.
-
-- [Slack](/maestro/integrations/slack) — Channel notifications
-- [Microsoft Teams](/maestro/integrations/teams) — Webhook notifications
-- [PagerDuty](/maestro/integrations/pagerduty) — Incident alerting
+Connect Maestro to the systems you already use. See [Integrations](/maestro/integrations) for the full list — data sources (Lakerunner, Postgres, Snowflake, BigQuery, Athena, ClickHouse), service integrations (GitHub, ServiceNow), and notifications (Slack, Teams, PagerDuty).

--- a/content/maestro/install/_meta.ts
+++ b/content/maestro/install/_meta.ts
@@ -1,0 +1,8 @@
+export default {
+  index: 'Overview',
+  'helm-chart': 'Helm Chart Reference',
+  environment: 'Environment Variables',
+  oidc: 'OIDC Setup',
+  bedrock: 'AWS Bedrock',
+  'first-steps': 'First Steps',
+}

--- a/content/maestro/install/bedrock.mdx
+++ b/content/maestro/install/bedrock.mdx
@@ -1,0 +1,151 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# AWS Bedrock
+
+Maestro supports Bedrock as a first-class LLM backend for both inference and embeddings. On EKS the recommended setup is **IRSA** (IAM Roles for Service Accounts) or **EKS Pod Identity** — the pod assumes a role that has Bedrock permissions, and no access keys ever touch the pod.
+
+## Supported models
+
+Claude Sonnet / Opus / Haiku (4.x) via Bedrock, Mistral Large 3 and Mistral 14B, and Amazon Titan for embeddings. The exact catalog is presented in the superadmin **LLM Model Catalog** page at runtime.
+
+## Choosing an auth method
+
+| Method | Use when | How |
+| ------ | -------- | --- |
+| **IRSA** | EKS, established IAM Role pattern | Annotate the service account with the role ARN |
+| **EKS Pod Identity** | EKS, newer clusters | Associate a pod identity with the service account |
+| **Static access keys** | Non-EKS clusters, dev | Enter key/secret in the LLM config UI |
+
+The chart does **not** need to know which one you're using. As long as the pod ends up with AWS credentials in its default credential chain, Maestro will find them. Leave `accessKeyId` / `secretAccessKey` blank in the LLM config and the SDK falls back to the pod credentials.
+
+## IRSA setup (EKS)
+
+### 1. Create an IAM policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Scope `Resource` down to specific model ARNs if you want (e.g. `arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-*`).
+
+### 2. Create an IAM role with a trust policy for the cluster's OIDC provider
+
+Replace `ACCOUNT`, `REGION`, `OIDC_ID`, `NAMESPACE`, and `SA_NAME`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/oidc.eks.REGION.amazonaws.com/id/OIDC_ID"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:sub": "system:serviceaccount:NAMESPACE:SA_NAME",
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:aud": "sts.amazonaws.com"
+        }
+      }
+    }
+  ]
+}
+```
+
+`SA_NAME` should match whatever the chart names the service account — by default, `<release>-maestro`. You can pin it with `serviceAccount.name` in values.
+
+Attach the Bedrock policy from step 1 to this role.
+
+### 3. Annotate the service account
+
+```yaml
+serviceAccount:
+  create: true
+  name: maestro            # pin the name to match the IAM trust policy
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/maestro-bedrock
+```
+
+### 4. Set the region
+
+The Bedrock client needs to know which region to call. Put it in `global.env` so both the Maestro pod and the gateway pick it up:
+
+```yaml
+global:
+  env:
+    - name: AWS_REGION
+      value: us-west-2
+```
+
+### 5. Configure the LLM in the UI
+
+After the pod restarts, log in as a superadmin:
+
+1. Go to **Admin → LLM Configs**
+2. Click **Create Config**
+3. Pick provider **Bedrock**
+4. Leave the access key and secret **blank**
+5. Set the region (or leave blank to fall back to `AWS_REGION`)
+6. Save
+
+Then head to **Admin → LLM Model Catalog** and enable the Bedrock models you want to expose.
+
+## EKS Pod Identity setup
+
+Pod Identity replaces IRSA on newer clusters. Instead of annotating the service account, you create a **Pod Identity Association** on the cluster:
+
+```bash
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace maestro \
+  --service-account maestro \
+  --role-arn arn:aws:iam::ACCOUNT:role/maestro-bedrock
+```
+
+Everything else is identical: the service account needs the right name, the role needs the Bedrock policy, and `AWS_REGION` needs to be set.
+
+## Static access keys
+
+If IRSA / Pod Identity aren't available (non-EKS, air-gapped, dev):
+
+1. Create an IAM user with the Bedrock policy attached
+2. Generate an access key / secret
+3. In **Admin → LLM Configs**, paste them into the Bedrock config alongside the region
+
+Nothing needs to go into Helm values — the credentials stay in the Maestro database.
+
+## Verifying it works
+
+In the admin UI, open a config and use the **Test** button (if present), or create an org, assign the Bedrock config to it, and run a chat. The first inference call will surface any auth problems in the Maestro pod logs:
+
+```bash
+kubectl -n maestro logs deploy/maestro-maestro | grep -i bedrock
+```
+
+Common failures:
+
+| Symptom | Cause |
+| ------- | ----- |
+| `UnrecognizedClientException` | Pod has no AWS credentials — IRSA annotation missing, or the SA name doesn't match the trust policy |
+| `AccessDeniedException on bedrock:InvokeModel` | IAM policy is missing the action or scoped too narrowly |
+| `ValidationException: model not accessible` | Bedrock model access hasn't been requested for the account in this region |
+| `Could not load credentials` | No `AWS_REGION` set **and** the credential chain is empty |
+
+Bedrock model access must be requested in the AWS console before the first call will succeed. It's a per-account, per-region toggle.
+
+<SupportCallout />

--- a/content/maestro/install/environment.mdx
+++ b/content/maestro/install/environment.mdx
@@ -1,0 +1,124 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Environment Variables
+
+Every environment variable Maestro and the MCP Gateway read at runtime. Set these via `maestro.env`, `mcpGateway.env`, or `global.env` in your `values.yaml`.
+
+Most of the really important knobs are here: OIDC, the public URL, and the AWS region for Bedrock. **Per-provider LLM credentials and per-org integration credentials are not env vars** — they live in the database and are managed through the admin UI.
+
+## Maestro
+
+### Database
+
+Usually set automatically by the chart — see the [Helm chart reference](/maestro/install/helm-chart#database).
+
+| Variable | Required | Default | Notes |
+| -------- | -------- | ------- | ----- |
+| `MAESTRO_DATABASE_URL` | Yes | — | Full PostgreSQL URL. The chart composes this from `database.*` values |
+| `MAESTRO_DB_HOST` | — | — | Set by chart from `database.host` |
+| `MAESTRO_DB_PORT` | — | `5432` | |
+| `MAESTRO_DB_NAME` | — | `maestro` | |
+| `MAESTRO_DB_USER` | — | `maestro` | |
+| `MAESTRO_DB_PASSWORD` | — | — | Sourced from the database secret |
+| `MAESTRO_DB_SSLMODE` | — | `require` | |
+
+### Public URL
+
+| Variable | Required | Default | Notes |
+| -------- | -------- | ------- | ----- |
+| `MAESTRO_BASE_URL` | Yes in prod | — | Full URL the browser hits (e.g. `https://maestro.example.com`). Must match your OIDC redirect URI |
+| `PORT` | — | `4200` | HTTP listen port |
+| `SPA_ROOT` | — | `/app/ui` | Path to the UI static bundle inside the image |
+
+### OIDC / authentication
+
+See [OIDC setup](/maestro/install/oidc) for a walkthrough.
+
+| Variable | Required | Default | Notes |
+| -------- | -------- | ------- | ----- |
+| `OIDC_ISSUER_URL` | Yes | — | Issuer URL of your IdP. JWKS is discovered from it |
+| `OIDC_AUDIENCE` | — | `maestro-ui` | Expected audience (client ID) |
+| `OIDC_JWKS_URL` | — | derived | Override if your IdP's JWKS lives outside the standard discovery path |
+| `OIDC_SUPERADMIN_GROUP` | — | `maestro-superadmin` | Users in this OIDC group are promoted to superadmin |
+| `OIDC_SUPERADMIN_EMAILS` | — | — | Comma-separated email allowlist. Matched case-insensitively. Use this to bootstrap the first superadmin before you've wired groups |
+| `OIDC_TRUST_UNVERIFIED_EMAILS` | — | `false` | Treat all OIDC emails as verified regardless of the `email_verified` claim. Only set this if you trust your IdP to gate email ownership itself (some Okta setups) |
+
+Maestro **always** requires `email_verified: true` in the token unless `OIDC_TRUST_UNVERIFIED_EMAILS=true`.
+
+### LLM providers (env var form)
+
+In normal operation you configure LLMs through the superadmin UI; those credentials live in the database. These env vars are only read by CLI provisioning helpers and the gateway's embedding path.
+
+| Variable | Used by | Notes |
+| -------- | ------- | ----- |
+| `ANTHROPIC_API_KEY` | CLI provisioning | |
+| `OPENAI_API_KEY` | CLI provisioning, gateway embeddings | |
+| `AWS_REGION` | Bedrock client default | When Bedrock creds are empty in the DB, the SDK falls back to the pod's credential chain and uses this region |
+| `GCP_PROJECT`, `GCP_REGION` | Vertex AI embeddings | |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Vertex AI embeddings (gateway) | Path to GCP service account key file |
+
+### MCP Gateway integration
+
+| Variable | Required | Default | Notes |
+| -------- | -------- | ------- | ----- |
+| `MCP_GATEWAY_URL` | — | `http://localhost:8080` | The chart sets this to the in-cluster service URL |
+| `MCP_GATEWAY_API_KEY` | — | — | If set, sent as `X-CardinalHQ-API-Key` to the gateway |
+
+### Default Lakerunner bucket
+
+Used by the Lakerunner provisioner when auto-configuring a new org's bucket. All four must be set together or all omitted.
+
+| Variable | Notes |
+| -------- | ----- |
+| `DEFAULT_BUCKET_NAME` | |
+| `DEFAULT_BUCKET_CLOUD_PROVIDER` | `aws`, `gcp`, `azure` |
+| `DEFAULT_BUCKET_REGION` | |
+| `DEFAULT_BUCKET_COLLECTOR_NAME` | |
+
+### Ontology / repos
+
+| Variable | Default | Notes |
+| -------- | ------- | ----- |
+| `ONTOLOGY_WORKSPACE_DIR` | `/tmp/ontology-workspaces` | Writable path for cloned repos. The default sits on the `tmp` emptyDir — fine for most installs |
+| `GITHUB_PAT` | — | Used by the ontology CLI, not at runtime |
+
+### Observability
+
+| Variable | Default | Notes |
+| -------- | ------- | ----- |
+| `OTEL_SERVICE_NAME` | `maestro` | |
+| `OTEL_TRACING_ENABLED` | `true` if endpoint set | Set to `false` to disable |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | HTTP OTLP endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | `Key=value,Key2=value2` |
+
+### Misc
+
+| Variable | Default | Notes |
+| -------- | ------- | ----- |
+| `DEBUG` | `false` | Enables `/api/debug/tools`. Do not set in prod |
+
+## MCP Gateway
+
+The gateway runs alongside Maestro and inherits most of its env from `global.env`. Unique vars:
+
+| Variable | Default | Notes |
+| -------- | ------- | ----- |
+| `MCP_HOST` | `0.0.0.0` | |
+| `MCP_PORT` | `8080` | Chart sets this from `mcpGateway.port` |
+| `MCP_DEBUG_PORT` | `9090` | Chart sets this from `mcpGateway.debugPort` |
+| `MCP_API_KEY` | — | If set, requests must carry `X-CardinalHQ-API-Key` |
+| `MCP_TRANSPORT` | `stdio` | Chart runs the gateway in HTTP mode; set to `http` if you ever override the entrypoint |
+| `MAESTRO_DATABASE_URL` | — | Same connection string as Maestro — required for per-org routing |
+| `DOCSTORE_DB_PATH` | auto-discovered | Path to `docstore.db` |
+| `WORKING_DIRECTORY` | cwd | Used for the embeddings cache |
+| `OTEL_SERVICE_NAME` | `mcp-gateway` | |
+
+## Where to set what
+
+| Scope | Use |
+| ----- | --- |
+| Public URL, OIDC, Postmark, superadmin email | `maestro.env` |
+| Bedrock region, OTel endpoint, trace headers | `global.env` (both workloads need them) |
+| MCP gateway specifics (API key in-container, docstore path) | `mcpGateway.env` or set on the chart-level field (`mcpGateway.apiKey`) |
+
+<SupportCallout />

--- a/content/maestro/install/first-steps.mdx
+++ b/content/maestro/install/first-steps.mdx
@@ -1,0 +1,96 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# First Steps as Superadmin
+
+You've installed the chart, the pod is healthy, OIDC is wired. Here's what to do on your first login.
+
+## 1. Log in
+
+Browse to `MAESTRO_BASE_URL`. You'll be redirected to your IdP, then back to Maestro. If your email is in `OIDC_SUPERADMIN_EMAILS` (or you're in `OIDC_SUPERADMIN_GROUP`), you'll see an **Admin** section in the sidebar. If not, jump back to [OIDC setup](/maestro/install/oidc#bootstrapping-the-first-superadmin).
+
+## 2. Configure at least one LLM
+
+Nothing else will work until there's an LLM backend.
+
+1. Go to **Admin → LLM Configs** and click **Create Config**
+2. Pick a provider:
+   - **Bedrock** — see the [Bedrock guide](/maestro/install/bedrock). Leave keys blank if using IRSA
+   - **Anthropic** — paste an API key
+   - **OpenAI-compatible** — paste a base URL and API key (works for OpenAI, Azure OpenAI, Groq, vLLM, etc.)
+3. Enable **inference** and/or **embeddings** on the config
+4. Save
+
+Then open **Admin → LLM Model Catalog** and select which specific models to expose. Maestro won't surface a model to org users until you've mapped it here.
+
+## 3. Create your first organization
+
+Everything in Maestro is scoped to an org. Users, integrations, chats, tokens — all of it.
+
+1. Go to **Admin → Organizations** and click **Create Org**
+2. Give it a name (e.g., `cardinal-internal`). The slug auto-generates from the name
+3. Set an owner email — this person becomes the org owner on their next login
+
+The owner can be you. If it is, refresh and you'll see the org in the main sidebar.
+
+## 4. Decide how users get in
+
+Two options:
+
+**Invitations (default).** An org owner goes to **Settings → People → Invitations** and invites users by email. They accept through a link (email delivery requires SMTP — see step 6).
+
+**Self-signup.** In **Admin → Settings**, toggle `allowSelfSignup`. Any user who logs in via OIDC can create their own org and becomes its owner. Use this for trusted internal deployments; leave it off otherwise.
+
+## 5. Add integrations
+
+Switch to an org context (pick the org from the sidebar). Then **Settings → Integrations → Add Integration**. Pick what you need:
+
+- [Lakerunner](/maestro/integrations/lakerunner) — almost certainly first
+- [PostgreSQL](/maestro/integrations/postgres), [Snowflake](/maestro/integrations/snowflake), [BigQuery](/maestro/integrations/bigquery), etc. — data sources
+- [GitHub](/maestro/integrations/github), [ServiceNow](/maestro/integrations/servicenow) — actions
+- [Slack](/maestro/integrations/slack), [Teams](/maestro/integrations/teams), [PagerDuty](/maestro/integrations/pagerduty) — notifications
+
+Every integration has a **Test Connection** button. Use it before saving. Credentials are encrypted at rest.
+
+## 6. Set up SMTP for invitations (optional but recommended)
+
+Without SMTP, the invite flow still works — you just have to copy-paste the invitation link by hand.
+
+1. Go to **Admin → System SMTP**
+2. Fill in host, port, credentials, from-address
+3. Send a test email
+
+## 7. Configure notifications (optional)
+
+For outbound notifications (alerts, daily summaries) use **Admin → Notification Integrations**. This is separate from per-org integrations — it's where you wire a Slack workspace or Teams channel that Maestro itself posts to for system events.
+
+## 8. Verify the whole stack
+
+Open a chat in your org and ask something concrete like *"what are the last 10 error logs from service X?"*. The agent should:
+
+1. Plan a step that calls a Lakerunner tool
+2. Execute it via the MCP Gateway
+3. Return the logs
+
+If it refuses or errors, check **Admin → Usage** (token usage proves LLM calls are going through) and the Maestro pod logs.
+
+## 9. Health checks for the cluster operator
+
+Point your liveness/readiness probes at `/api/health`:
+
+```
+GET /api/health
+{"status":"ok","service":"maestro","version":"..."}
+```
+
+The chart already wires this for both liveness and readiness. If you put a separate uptime monitor in front of Maestro, this is the endpoint to hit — it doesn't require auth.
+
+For operational visibility, **Admin → System Health** surfaces per-org Lakerunner instance health and recent errors.
+
+## Day-two concerns
+
+- **Backups**: everything important is in Postgres. Back that up.
+- **Upgrades**: bump `image.tag` in your `values.yaml`, `helm upgrade`, verify `/api/health` is still returning the new version. Migrations run automatically on startup.
+- **Secret rotation**: the database password is the only secret the chart creates. For BYO secrets (OIDC client secret if you add one, LLM keys stored in DB, integration credentials) — those live outside the chart.
+- **Scale**: `maestro.replicas` can go above 1 only if you've front-ended Maestro with a load balancer that does session affinity. The current session storage is per-pod. Plan to revisit if you need HA.
+
+<SupportCallout />

--- a/content/maestro/install/helm-chart.mdx
+++ b/content/maestro/install/helm-chart.mdx
@@ -1,0 +1,159 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Helm Chart Reference
+
+Every field in `values.yaml` for the `maestro` Helm chart. Defaults shown are from the chart (`charts/maestro/values.yaml`).
+
+## Image
+
+A single unified image runs both workloads. The chart picks the entrypoint.
+
+```yaml
+image:
+  repository: public.ecr.aws/cardinalhq.io/maestro
+  tag: ""            # empty → Chart.appVersion (recommended: pin to a released tag)
+  pullPolicy: IfNotPresent
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `image.repository` | `public.ecr.aws/cardinalhq.io/maestro` | Also mirrored to `ghcr.io/cardinalhq/maestro` |
+| `image.tag` | `""` (falls back to `Chart.appVersion`) | Pin this. Do not let it float. |
+| `image.pullPolicy` | `IfNotPresent` | Kubernetes image pull policy |
+
+## Maestro workload
+
+```yaml
+maestro:
+  enabled: true
+  replicas: 1
+  port: 4200
+  resources: {}
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  env: []                 # extra env vars (auth, LLM, etc.)
+  extraVolumes: []
+  extraVolumeMounts: []
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `maestro.enabled` | `true` | Disable only if you want to run the gateway alone |
+| `maestro.replicas` | `1` | Maestro is stateless but session cookies are not sticky-bound — keep at `1` unless you've set up shared session storage |
+| `maestro.port` | `4200` | Container port; also the Service port |
+| `maestro.env` | `[]` | **This is where you put OIDC, LLM, and `MAESTRO_BASE_URL` vars.** See [Environment variables](/maestro/install/environment) |
+| `maestro.extraVolumes` / `extraVolumeMounts` | `[]` | Mount extra config or certs into the pod |
+
+The Maestro pod runs with `readOnlyRootFilesystem: true`. A `tmp` emptyDir is mounted at `/tmp`. If you need additional writable paths (e.g., ontology workspaces), add them via `extraVolumes` + `extraVolumeMounts`.
+
+An `initContainer` waits for the MCP gateway service to accept connections before Maestro starts.
+
+## MCP Gateway workload
+
+```yaml
+mcpGateway:
+  enabled: true
+  replicas: 1
+  port: 8080
+  debugPort: 9090
+  apiKey: ""
+  resources: {}
+  labels: {}
+  annotations: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  env: []
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `mcpGateway.enabled` | `true` | Must be enabled for integrations to work |
+| `mcpGateway.port` | `8080` | Maestro reaches the gateway at `http://<release>-mcp-gateway:8080` |
+| `mcpGateway.debugPort` | `9090` | pprof / debug endpoints — do **not** expose externally |
+| `mcpGateway.apiKey` | `""` | Injected as `MCP_API_KEY`. Leave empty for in-cluster trust; set it if the gateway is reachable beyond the namespace |
+| `mcpGateway.env` | `[]` | Extra env for the gateway (e.g. `AWS_REGION` for Bedrock embeddings) |
+
+## Database
+
+Required. Maestro will not start without it.
+
+```yaml
+database:
+  secretName: "pg-credentials"
+  create: true
+  passwordKey: "MAESTRO_DB_PASSWORD"
+  host: ""               # required
+  port: 5432
+  name: "maestro"
+  username: "maestro"
+  password: ""           # only used when create: true
+  sslMode: "require"
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `database.create` | `true` | When `true`, the chart creates a `Secret` named `<release>-<secretName>` with `password` base64-encoded. **In prod, set to `false` and manage the secret yourself** (SealedSecrets, External Secrets, etc.) |
+| `database.secretName` | `pg-credentials` | When `create: true`, gets prefixed with the release name. When `create: false`, used verbatim |
+| `database.passwordKey` | `MAESTRO_DB_PASSWORD` | Key within the secret |
+| `database.host` | `""` | **Required.** PostgreSQL hostname |
+| `database.port` | `5432` | |
+| `database.name` | `maestro` | Database name (must exist; Maestro does not create it) |
+| `database.username` | `maestro` | |
+| `database.sslMode` | `require` | One of `disable`, `require`, `verify-ca`, `verify-full` |
+
+The chart synthesizes `MAESTRO_DATABASE_URL` from these fields and injects it into both workloads — you do not need to set it yourself.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls: []
+```
+
+The built-in Ingress is a minimal `networking.k8s.io/v1` object that points at the Maestro service. It works for NGINX, Traefik, or anything that honors `ingressClassName`. If you need more control (IngressRoute, Gateway API, multiple hosts), disable this and create your own routing resource — the Maestro service is `<release>-maestro` on port `4200`.
+
+## Service account
+
+```yaml
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `serviceAccount.create` | `true` | Creates the SA used by both workloads |
+| `serviceAccount.name` | `""` | Override the generated name |
+| `serviceAccount.annotations` | `{}` | **Add IRSA annotation here for Bedrock.** See [AWS Bedrock](/maestro/install/bedrock) |
+
+## Global
+
+Applied to both workloads.
+
+```yaml
+global:
+  imagePullSecrets: []
+  env: []                 # env vars merged into both containers
+  labels: {}
+  annotations: {}
+```
+
+| Field | Default | Notes |
+| ----- | ------- | ----- |
+| `global.imagePullSecrets` | `[]` | List of secret names for pulling from private registries |
+| `global.env` | `[]` | Env vars that apply to both Maestro and the gateway. Use for `AWS_REGION`, tracing config, etc. |
+| `global.labels` | `{}` | Merged into every resource's labels |
+| `global.annotations` | `{}` | Merged into every resource's annotations |
+
+Scheduling fields (`nodeSelector`, `tolerations`, `affinity`) can also be set at the `global` level and are merged with per-workload overrides.
+
+<SupportCallout />

--- a/content/maestro/install/index.mdx
+++ b/content/maestro/install/index.mdx
@@ -1,0 +1,112 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Installing Maestro on Kubernetes
+
+Maestro is Cardinal's agent server. It runs as a single pod behind a Helm chart that also includes the MCP Gateway and the Cardinal web UI. The whole stack ships as one container image — the Helm chart simply runs it twice with different entrypoints.
+
+## Architecture
+
+The chart deploys two workloads:
+
+| Component | What it does | Port |
+| --------- | ------------ | ---- |
+| **maestro** | HTTP server, serves the UI, handles auth, runs the agent | `4200` |
+| **mcp-gateway** | MCP server that exposes integration tools (Lakerunner, etc.) | `8080` (public) / `9090` (debug) |
+
+Both containers come from the same image — `public.ecr.aws/cardinalhq.io/maestro` — so there is only ever one `image.tag` to update. Maestro talks to the gateway over `ClusterIP` inside the namespace.
+
+## Prerequisites
+
+- A Kubernetes cluster (1.27+)
+- `helm` 3.13+
+- A PostgreSQL database reachable from the cluster (RDS, CloudSQL, or in-cluster is fine)
+- An OIDC provider (Keycloak, Okta, Auth0, Google Workspace, etc.) — required for login
+- An LLM backend — one of:
+  - AWS Bedrock (via IRSA — recommended on EKS)
+  - Anthropic API
+  - An OpenAI-compatible endpoint
+- A hostname and TLS cert for the ingress (Maestro expects to be reached at a single public URL)
+
+## Chart location
+
+The chart is published as an OCI artifact:
+
+```
+oci://public.ecr.aws/cardinalhq.io/maestro
+```
+
+Source lives at [github.com/cardinalhq/charts](https://github.com/cardinalhq/charts) under `maestro/`.
+
+## Minimal install
+
+Create a `values.yaml`:
+
+```yaml
+image:
+  tag: v0.20.1
+
+database:
+  create: false          # bring your own secret (recommended for prod)
+  secretName: pg-credentials
+  host: postgres.example.com
+  port: 5432
+  name: maestro
+  username: maestro
+  sslMode: require
+
+maestro:
+  env:
+    - name: MAESTRO_BASE_URL
+      value: https://maestro.example.com
+    - name: OIDC_ISSUER_URL
+      value: https://auth.example.com/realms/cardinal
+    - name: OIDC_AUDIENCE
+      value: maestro-ui
+    - name: OIDC_SUPERADMIN_EMAILS
+      value: admin@example.com
+
+ingress:
+  enabled: true
+  className: traefik
+  host: maestro.example.com
+  tls:
+    - secretName: maestro-tls
+      hosts:
+        - maestro.example.com
+```
+
+Pre-create the database password secret (since `database.create: false`):
+
+```bash
+kubectl create secret generic pg-credentials \
+  --from-literal=MAESTRO_DB_PASSWORD='...' \
+  -n maestro
+```
+
+Install:
+
+```bash
+helm install maestro oci://public.ecr.aws/cardinalhq.io/maestro \
+  --version 0.4.4 \
+  -n maestro --create-namespace \
+  -f values.yaml
+```
+
+Verify:
+
+```bash
+kubectl -n maestro get pods
+kubectl -n maestro port-forward svc/maestro-maestro 4200:4200
+curl http://localhost:4200/api/health
+# {"status":"ok","service":"maestro","version":"..."}
+```
+
+## Where to go next
+
+1. [Helm chart reference](/maestro/install/helm-chart) — every field in `values.yaml`
+2. [Environment variables](/maestro/install/environment) — full env var catalog
+3. [OIDC setup](/maestro/install/oidc) — wiring Keycloak, Okta, or any OIDC IdP
+4. [AWS Bedrock](/maestro/install/bedrock) — IRSA-based pod credentials
+5. [First steps as superadmin](/maestro/install/first-steps) — what to do after the first login
+
+<SupportCallout />

--- a/content/maestro/install/oidc.mdx
+++ b/content/maestro/install/oidc.mdx
@@ -1,0 +1,147 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# OIDC Setup
+
+Maestro delegates all authentication to an external OIDC provider. There is no built-in password login. Every user who signs in must exist in your IdP first.
+
+## How Maestro uses OIDC
+
+- The browser performs the standard Authorization Code flow against your IdP.
+- Maestro validates the resulting ID token against the provider's JWKS.
+- The token's `email` claim identifies the user. `email_verified` must be `true`.
+- Superadmin status is derived from either an OIDC **group** claim or an **email allowlist**. A user who matches either becomes a superadmin on first login.
+- Regular users start with no org membership. A superadmin (or an org owner) must place them in an org before they can do anything useful.
+
+## Required environment variables
+
+Set these in `maestro.env`:
+
+```yaml
+maestro:
+  env:
+    - name: MAESTRO_BASE_URL
+      value: https://maestro.example.com
+    - name: OIDC_ISSUER_URL
+      value: https://auth.example.com/realms/cardinal
+    - name: OIDC_AUDIENCE
+      value: maestro-ui
+    - name: OIDC_SUPERADMIN_EMAILS
+      value: admin@example.com,ops@example.com
+```
+
+| Variable | Notes |
+| -------- | ----- |
+| `MAESTRO_BASE_URL` | Must exactly match the redirect URI registered with your IdP |
+| `OIDC_ISSUER_URL` | Used for JWKS discovery (`{issuer}/.well-known/openid-configuration`) |
+| `OIDC_AUDIENCE` | The `aud` claim Maestro expects. Defaults to `maestro-ui` |
+| `OIDC_SUPERADMIN_GROUP` | Name of a `groups` claim value granting superadmin. Default `maestro-superadmin` |
+| `OIDC_SUPERADMIN_EMAILS` | Comma-separated email allowlist for superadmin. Case-insensitive. Use this to bootstrap before groups are configured |
+| `OIDC_JWKS_URL` | Override if your JWKS is at a non-standard path |
+| `OIDC_TRUST_UNVERIFIED_EMAILS` | `true` treats all OIDC emails as verified. Only use with IdPs that gate email ownership in another way |
+
+## Redirect URI
+
+Register the following redirect URI with your IdP (where `MAESTRO_BASE_URL` is whatever you set):
+
+```
+https://maestro.example.com/api/auth/callback
+```
+
+## Required token claims
+
+Maestro reads these claims out of the ID token. Configure your IdP to include them:
+
+| Claim | Required | Purpose |
+| ----- | -------- | ------- |
+| `sub` | Yes | Stable user identifier |
+| `email` | Yes | Primary user key |
+| `email_verified` | Yes (or set `OIDC_TRUST_UNVERIFIED_EMAILS=true`) | Prevents email spoofing |
+| `name` | Recommended | Displayed in the UI |
+| `groups` | If using group-based superadmin | Array of group names |
+
+## Bootstrapping the first superadmin
+
+On a fresh install, no users exist in the database. When the first person logs in:
+
+1. They authenticate with your IdP as usual.
+2. Maestro looks at their `email` (and `groups`, if any).
+3. If the email is listed in `OIDC_SUPERADMIN_EMAILS` **or** their groups contain `OIDC_SUPERADMIN_GROUP`, the user is auto-upserted with `role=superadmin`.
+4. Otherwise they land as a regular user with no org — and they'll see a "contact your administrator" screen.
+
+The practical pattern: set `OIDC_SUPERADMIN_EMAILS` to your own email during install so you can log in and configure the rest. Once group mappings are working end-to-end, you can remove the allowlist.
+
+## Keycloak
+
+Maestro is developed against Keycloak and the docker-compose dev stack uses it as the default IdP.
+
+1. Create a new realm (e.g. `cardinal`).
+2. Create a client:
+   - Client ID: `maestro-ui`
+   - Client type: `OpenID Connect`
+   - Client authentication: **off** (public client — the UI is a browser SPA)
+   - Standard flow: **on**
+   - Valid redirect URIs: `https://maestro.example.com/*`
+   - Web origins: `https://maestro.example.com`
+3. Under **Client scopes → maestro-ui-dedicated → Add mapper**, add a **Group Membership** mapper:
+   - Token Claim Name: `groups`
+   - Full group path: **off**
+   - Add to ID token: **on**
+   - Add to userinfo: **on**
+4. Create a group `maestro-superadmin` and add yourself to it.
+5. Set:
+   ```yaml
+   - name: OIDC_ISSUER_URL
+     value: https://keycloak.example.com/realms/cardinal
+   - name: OIDC_AUDIENCE
+     value: maestro-ui
+   - name: OIDC_SUPERADMIN_GROUP
+     value: maestro-superadmin
+   ```
+
+## Okta
+
+1. Create an OIDC **Single-Page Application**.
+2. Sign-in redirect URI: `https://maestro.example.com/api/auth/callback`.
+3. Add a **Groups claim** to the ID token — filter to the groups you care about.
+4. Assign users to a group (e.g. `maestro-superadmin`) and assign that group to the app.
+5. Set:
+   ```yaml
+   - name: OIDC_ISSUER_URL
+     value: https://{your-okta-domain}/oauth2/default
+   - name: OIDC_AUDIENCE
+     value: {the app's client ID}
+   - name: OIDC_SUPERADMIN_GROUP
+     value: maestro-superadmin
+   ```
+
+Some Okta setups don't populate `email_verified`. If users hit a "your email is not verified" error and you trust Okta's identity proofing, add:
+
+```yaml
+- name: OIDC_TRUST_UNVERIFIED_EMAILS
+  value: "true"
+```
+
+## Google Workspace
+
+Google OIDC does not issue a `groups` claim out of the box. Use the email allowlist:
+
+```yaml
+- name: OIDC_ISSUER_URL
+  value: https://accounts.google.com
+- name: OIDC_AUDIENCE
+  value: {your-client-id}.apps.googleusercontent.com
+- name: OIDC_SUPERADMIN_EMAILS
+  value: alice@example.com,bob@example.com
+```
+
+## Troubleshooting
+
+| Symptom | Cause |
+| ------- | ----- |
+| Redirect loop after login | `MAESTRO_BASE_URL` doesn't match the redirect URI registered with the IdP, or it's behind a different hostname than the browser is using |
+| "Invalid token audience" | `OIDC_AUDIENCE` doesn't match the token's `aud` claim (for some IdPs this is the client ID; for others it's a custom resource identifier) |
+| "Your email is not verified" | The IdP is omitting `email_verified` or setting it to `false`. Fix at the IdP, or set `OIDC_TRUST_UNVERIFIED_EMAILS=true` if appropriate |
+| Logged in but no admin menu | You're not in `OIDC_SUPERADMIN_GROUP` **and** not in `OIDC_SUPERADMIN_EMAILS`. Add yourself to one of them and log out / back in |
+| JWKS fetch errors in logs | `OIDC_ISSUER_URL` unreachable from the pod, or the IdP's JWKS lives outside the standard discovery path — set `OIDC_JWKS_URL` explicitly |
+
+<SupportCallout />


### PR DESCRIPTION
## Summary
- Adds a new **Installation** section under `content/maestro/install/` covering the Helm chart, env var catalog, OIDC setup (Keycloak / Okta / Google), AWS Bedrock via IRSA or Pod Identity, and a superadmin first-steps walkthrough
- Renames the top-level nav label from "Product" to "Maestro" and rewrites `content/maestro/index.mdx` to focus on what Maestro is and does (agentic observability, Lakerunner explore)

## Test plan
- [ ] `pnpm dev` renders the new pages under `/maestro/install/*`
- [ ] Sidebar shows **Maestro** as a top-level item with **Installation** and **Integrations** underneath
- [ ] Internal links resolve (install overview → helm-chart / environment / oidc / bedrock / first-steps; first-steps → integrations)