### PR TITLE
docs: OpenShift compatibility for maestro + lakerunner Helm charts

### DIFF
--- a/content/lakerunner/install.mdx
+++ b/content/lakerunner/install.mdx
@@ -29,6 +29,49 @@ Configure an Ingress or use port-forwarding to access Grafana:
 kubectl port-forward -n lakerunner svc/grafana 3000:3000
 ```
 
+## Deploying on OpenShift
+
+The chart renders cleanly under the `restricted-v2` SCC with two adjustments. Add the following to the `values.yaml` produced by the wizard above:
+
+### 1. Let the SCC assign UIDs
+
+OpenShift's `restricted-v2` SCC rejects pods whose `runAsUser`/`runAsGroup`/`fsGroup` fall outside the namespace's assigned UID range — it wants to inject them from the range itself. Null the fields so the chart emits only `runAsNonRoot: true`:
+
+```yaml copy
+global:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+grafana:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+```
+
+The SCC fills in `runAsUser`, `runAsGroup`, and `fsGroup`. All other hardening from `global.containerSecurityContext` (no-privilege-escalation, drop `ALL`, `RuntimeDefault` seccomp, read-only rootfs) stays in effect.
+
+### 2. Grafana needs an SCC that permits UID 472
+
+The upstream `grafana/grafana` image expects UID 472 to own `/var/lib/grafana`. Because that UID almost never falls inside a namespace's `restricted-v2` range, Grafana needs either a custom SCC or an OpenShift-compatible image. The simplest path is:
+
+```sh copy
+oc adm policy add-scc-to-user nonroot-v2 -z <release>-lakerunner -n <namespace>
+```
+
+…and then keep Grafana's defaults (UID 472). If you prefer to avoid the SCC grant, swap `grafana.image.repository` for an image that supports random UIDs.
+
+### 3. Perch needs elevated RBAC
+
+The Perch component ships with a `ClusterRole` that includes `patch` on `apps/deployments` cluster-wide — this is its legitimate function (cross-namespace deployment management), but it counts as a privileged grant. On clusters with strict RBAC review you may need admin approval or an `oc adm policy add-role-to-user edit` against the chart's ServiceAccount.
+
+### 4. Ingress / Routes
+
+The chart uses standard `networking.k8s.io/v1` `Ingress` resources. They work with the OpenShift HAProxy router out of the box; no nginx-specific annotations are emitted.
+
 ## Upgrading
 
 To upgrade an existing installation:

--- a/content/maestro/install/helm-chart.mdx
+++ b/content/maestro/install/helm-chart.mdx
@@ -145,6 +145,19 @@ global:
   env: []                 # env vars merged into both containers
   labels: {}
   annotations: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 ```
 
 | Field | Default | Notes |
@@ -153,7 +166,26 @@ global:
 | `global.env` | `[]` | Env vars that apply to both Maestro and the gateway. Use for `AWS_REGION`, tracing config, etc. |
 | `global.labels` | `{}` | Merged into every resource's labels |
 | `global.annotations` | `{}` | Merged into every resource's annotations |
+| `global.podSecurityContext` | `runAsNonRoot: true`, UID/GID/fsGroup `65532` | Pod-level `securityContext` applied to every workload. Per-component overrides at `<component>.podSecurityContext` win, missing fields fall back to the globals |
+| `global.containerSecurityContext` | no-privilege-escalation, read-only rootfs, drop `ALL` caps, `RuntimeDefault` seccomp | Container-level hardening applied to every container. Per-component overrides at `<component>.containerSecurityContext` |
 
 Scheduling fields (`nodeSelector`, `tolerations`, `affinity`) can also be set at the `global` level and are merged with per-workload overrides.
+
+## Deploying on OpenShift
+
+The chart renders cleanly under the `restricted-v2` SCC once the UID fields are nulled out so the SCC can inject values from the namespace's assigned UID range:
+
+```yaml
+global:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+```
+
+With that in place the pod `securityContext` emits only `runAsNonRoot: true`; the SCC fills in `runAsUser`, `runAsGroup`, and `fsGroup`. All other hardening from `global.containerSecurityContext` (no-privilege-escalation, drop `ALL`, `RuntimeDefault` seccomp, read-only rootfs) stays in effect.
+
+The built-in `Ingress` is a standard `networking.k8s.io/v1` resource with a configurable `ingressClassName` — the OpenShift HAProxy router handles it out of the box; no nginx-specific annotations are emitted.
 
 <SupportCallout />


### PR DESCRIPTION
## Summary
- Surface the OpenShift SCC guidance that lives in the chart READMEs (`../charts/{maestro,lakerunner}/README.md`) into the product docs so users don't have to dig into the chart repo to find it.
- **Maestro**: `content/maestro/install/helm-chart.mdx` now documents `global.podSecurityContext` / `global.containerSecurityContext` (which existed in the chart but weren't in the reference) and adds a "Deploying on OpenShift" subsection covering the `restricted-v2` SCC UID nulling and the HAProxy ingress.
- **Lakerunner**: `content/lakerunner/install.mdx` gains a "Deploying on OpenShift" section after the wizard output — UID nulling for both `global` and `grafana`, the `nonroot-v2` SCC grant for Grafana's UID 472, the Perch ClusterRole note, and the HAProxy ingress note.

## Test plan
- [x] `pnpm build` passes
- [ ] Spot-check rendered pages locally