### PR TITLE
Fix Dependabot security alerts (postcss, uuid)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "overrides": {
       "@xmldom/xmldom": ">=0.9.10",
       "dompurify": ">=3.4.0",
-      "lodash-es": ">=4.18.0"
+      "lodash-es": ">=4.18.0",
+      "postcss": ">=8.5.10",
+      "uuid": ">=14.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@xmldom/xmldom': '>=0.9.10'
   dompurify: '>=3.4.0'
   lodash-es: '>=4.18.0'
+  postcss: '>=8.5.10'
+  uuid: '>=14.0.0'
 
 importers:
 
@@ -2844,8 +2846,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -3330,8 +3332,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6392,7 +6394,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 11.1.0
+      uuid: 14.0.0
 
   mhchemparser@4.2.1: {}
 
@@ -6732,7 +6734,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.24
       caniuse-lite: 1.0.30001791
-      postcss: 8.4.31
+      postcss: 8.5.12
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6969,7 +6971,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.4.31:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7589,7 +7591,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- Adds pnpm overrides for `postcss >=8.5.10` (was 8.4.31, alert #81) and `uuid >=14.0.0` (was 11.1.0, alert #80)
- Both are transitive dependencies (postcss via next, uuid via mermaid/nextra)
- pnpm install resolves to postcss@8.5.12 and uuid@14.0.0

## Alerts addressed
- Alert #81: postcss < 8.5.10 (medium)
- Alert #80: uuid < 14.0.0 (medium)

## Test plan
- [ ] Verify Dependabot alerts #80 and #81 are dismissed after merge
- [ ] Confirm `pnpm install` and `pnpm build` succeed in CI