### PR TITLE
ci: add build+test PR check workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,34 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: ['main']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- New workflow runs `pnpm test` (Jest, includes link-checker) and `pnpm build` (Next.js / Nextra) on every PR targeting `main`.
- Existing `nextjs.yml` (post-merge build + Pages deploy) is unchanged.

After this lands, branch protection on `main` will require the `build-and-test` check.

## Test plan
- [ ] Workflow runs on this PR and turns green