### PR TITLE
docs(maestro/kubernetes): OpenShift quickstart section

### DIFF
--- a/content/maestro/integrations/kubernetes.mdx
+++ b/content/maestro/integrations/kubernetes.mdx
@@ -165,6 +165,132 @@ kubectl config view --raw -o jsonpath='{.clusters[?(@.name=="<your-context>")].c
 7. Fill in **Name**, **Description**, and **Planner Hint** as needed.
 8. Click **Create**.
 
+## OpenShift quickstart
+
+The setup above works on OpenShift too — the manifests are vanilla Kubernetes RBAC. Two small changes make for a smoother install:
+
+1. Put everything in a dedicated `Project` so uninstall is a single `oc delete project`.
+2. Add OpenShift-native resources (`route.openshift.io/routes`, `apps.openshift.io/deploymentconfigs`) to the `ClusterRole` so the agent can inspect them.
+
+### 1. Apply RBAC
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: cardinal-mcp
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cardinal-mcp-reader
+  namespace: cardinal-mcp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cardinal-mcp-reader
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - services
+      - endpoints
+      - events
+      - configmaps
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - serviceaccounts
+      - replicationcontrollers
+      - resourcequotas
+      - limitranges
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["selfsubjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cardinal-mcp-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cardinal-mcp-reader
+subjects:
+  - kind: ServiceAccount
+    name: cardinal-mcp-reader
+    namespace: cardinal-mcp
+EOF
+```
+
+### 2. Create a long-lived token Secret
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cardinal-mcp-reader-token
+  namespace: cardinal-mcp
+  annotations:
+    kubernetes.io/service-account.name: cardinal-mcp-reader
+type: kubernetes.io/service-account-token
+EOF
+```
+
+### 3. Extract the values Cardinal needs
+
+```bash
+# API server URL — e.g. https://api.acme-prod.example.com:6443
+oc whoami --show-server
+
+# CA certificate (PEM)
+oc -n cardinal-mcp get secret cardinal-mcp-reader-token \
+  -o jsonpath='{.data.ca\.crt}' | base64 -d
+
+# Bearer token
+oc -n cardinal-mcp get secret cardinal-mcp-reader-token \
+  -o jsonpath='{.data.token}' | base64 -d
+```
+
+Paste those three values into **Settings > Integrations > Add Integration > Kubernetes**, then click **Test Connection**.
+
+**Uninstall**: `oc delete project cardinal-mcp && oc delete clusterrole cardinal-mcp-reader && oc delete clusterrolebinding cardinal-mcp-reader`.
+
 ## Using Explore correlation
 
 Once the integration is created:


### PR DESCRIPTION
Customer onboarding ask. Adds a copy-pasteable OpenShift install path to the Kubernetes integration page — same shape as the vanilla setup above, with three OpenShift-friendly tweaks:
- Dedicated `Project` so uninstall is one `oc delete project`.
- Includes `route.openshift.io/routes` + `apps.openshift.io/deploymentconfigs` in the ClusterRole.
- Uses `oc` and `oc whoami --show-server` instead of kubectl + manual kubeconfig grep.

Sits between the existing Setup section and Using Explore correlation so vanilla-k8s users still see the standard flow first.