### PR TITLE
docs(maestro): add Databricks integration page

### DIFF
--- a/content/maestro/_meta.ts
+++ b/content/maestro/_meta.ts
@@ -5,4 +5,5 @@ export default {
   },
   install: 'Installation',
   integrations: 'Integrations',
+  admin: 'Administration',
 }

--- a/content/maestro/admin/_meta.ts
+++ b/content/maestro/admin/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  'token-limits': 'Token Limits',
+}

--- a/content/maestro/admin/token-limits.mdx
+++ b/content/maestro/admin/token-limits.mdx
@@ -1,0 +1,51 @@
+# Token Limits
+
+Maestro caps daily LLM token consumption in two complementary ways.
+
+- **Org aggregate cap** (set by your CardinalHQ administrator) — the **sum of all users'** daily tokens for a given model in your organization cannot exceed this number.
+- **Per-user cap** (set by org owners) — each user's own daily tokens for a given model cannot exceed their effective per-user limit. Org owners assign each user a value of `Default`, `Unlimited`, or a custom number, with an org-wide per-user default applied to anyone without an explicit override.
+
+Both caps are evaluated independently at request entry. A request is admitted only if **neither** cap has been reached. The total counts `input + output + cache_read + cache_write` tokens. Embedding usage is excluded.
+
+## Resets
+
+All caps reset at **00:00 UTC**.
+
+## Where to manage limits
+
+### CardinalHQ administrators (per-org aggregate)
+
+Per-org aggregate caps live on the **Organization Detail** page (administration UI), in the **Daily Aggregate Token Limits** section. Pick a model, set a daily cap (or leave blank for unlimited), toggle Enabled, Save.
+
+### Org owners (per-user)
+
+In your organization's **Settings → Token Limits** page:
+
+- **Per-user default** — sets the daily cap that applies to each user in the org by default. Can be `Unlimited` or a custom number.
+- **Overrides — by user** — pick a member, choose `Default` / `Unlimited` / `Custom: <n>` per model.
+- **Overrides — by model** — pick a model, see every user's current override and today's usage at a glance.
+
+The org aggregate cap is shown read-only on this page so org owners know the operator-imposed ceiling.
+
+## Over-limit behavior
+
+When a request would start while a cap is already met, Maestro responds with HTTP **429 Too Many Requests**. The body identifies which cap tripped:
+
+```json
+{
+  "code": "token_limit_exceeded",
+  "scope": "user",
+  "model": "claude-sonnet-4-6",
+  "used": 1234567,
+  "limit": 1000000,
+  "resetAt": "2026-05-10T00:00:00Z"
+}
+```
+
+`scope` is `"user"` (this user has hit their personal cap) or `"org"` (the organization has hit its aggregate cap). When both caps are over, the response reports `"org"`.
+
+A turn that started below the cap is allowed to finish; the **next** request is what bounces.
+
+## v1 caveat
+
+This first cut of token-limit enforcement counts only the LLM calls that the orchestra adapter currently records to `maestro_llm_usage_records` (turn-completion events). Internal calls made by the planner, the chat formatter, and compaction are not yet ledgered, so real consumption may be slightly higher than what the cap sees. We're closing this gap as a follow-up.

--- a/content/maestro/admin/token-limits.mdx
+++ b/content/maestro/admin/token-limits.mdx
@@ -46,6 +46,3 @@ When a request would start while a cap is already met, Maestro responds with HTT
 
 A turn that started below the cap is allowed to finish; the **next** request is what bounces.
 
-## v1 caveat
-
-This first cut of token-limit enforcement counts only the LLM calls that the orchestra adapter currently records to `maestro_llm_usage_records` (turn-completion events). Internal calls made by the planner, the chat formatter, and compaction are not yet ledgered, so real consumption may be slightly higher than what the cap sees. We're closing this gap as a follow-up.

--- a/content/maestro/integrations/_meta.ts
+++ b/content/maestro/integrations/_meta.ts
@@ -3,6 +3,7 @@ export default {
   athena: 'Amazon Athena',
   clickhouse: 'ClickHouse',
   confluence: 'Confluence',
+  databricks: 'Databricks',
   github: 'GitHub',
   bigquery: 'Google BigQuery',
   jira: 'Jira',

--- a/content/maestro/integrations/databricks.mdx
+++ b/content/maestro/integrations/databricks.mdx
@@ -1,0 +1,68 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Databricks
+
+Connect Cardinal to a Databricks SQL warehouse to explore Unity Catalog schemas and query your lakehouse using natural language.
+
+## Overview
+
+With the Databricks integration, the AI agent can:
+
+- **Explore catalogs and schemas** — browse tables, columns, and data types in Unity Catalog
+- **Run queries** — answer questions about your data using natural language
+- **Analyze lakehouse data** — leverage Databricks SQL warehouses for analytical queries
+
+## Capabilities
+
+| Capability | Enabled |
+| ---------- | ------- |
+| Explore | Always |
+| Agent | Always |
+
+## Configuration
+
+### Settings
+
+| Field | Required | Default | Description |
+| ----- | -------- | ------- | ----------- |
+| **Server Hostname** | Yes | — | Workspace hostname without `https://` (e.g., `dbc-xxxxxxxx-xxxx.cloud.databricks.com`) |
+| **HTTP Path** | Yes | — | SQL warehouse HTTP path (e.g., `/sql/1.0/warehouses/abc123def456`) |
+| **Catalog** | Yes | — | Unity Catalog name to query (e.g., `main`, `samples`) |
+| **Schema** | Yes | — | Schema within the catalog. Comma-separated for multiple schemas |
+
+### Credentials
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| **Access Token** | Yes | Databricks personal access token (starts with `dapi`) |
+
+## Prerequisites
+
+- A Databricks workspace with a running (or auto-resumable) **SQL warehouse**
+- A **personal access token** (or service principal token) with read access to the catalog and schemas you want to explore — read-only is recommended
+- The token's principal granted `USE CATALOG` / `USE SCHEMA` / `SELECT` on the relevant Unity Catalog objects
+
+## Finding Your Connection Details
+
+In the Databricks workspace, open **SQL Warehouses**, click the warehouse you want to use, and open the **Connection details** tab. Copy the **Server hostname** and **HTTP path** from there.
+
+To create an access token: click your avatar (top-right) → **Settings** → **Developer** → **Access tokens** → **Generate new token**.
+
+## Setup
+
+1. Navigate to **Settings > Integrations** and click **Add Integration**
+2. Select **Databricks**
+3. Enter the **Server Hostname** and **HTTP Path** from the warehouse's Connection details
+4. Enter the **Catalog** and **Schema** you want the agent to explore
+5. Enter the **Access Token**
+6. Click **Test Connection** to verify connectivity
+7. Click **Save**
+
+## What This Enables
+
+Once configured, you can ask the AI agent questions like:
+- "What's the total revenue by region this quarter?"
+- "Show me the schema for the orders table"
+- "How many distinct users had a session yesterday?"
+
+<SupportCallout />

--- a/content/maestro/integrations/index.mdx
+++ b/content/maestro/integrations/index.mdx
@@ -25,6 +25,7 @@ Each integration enables one or more capabilities:
 | [Snowflake](/maestro/integrations/snowflake) | Explore, Agent | Query Snowflake data warehouses using natural language |
 | [Amazon Athena](/maestro/integrations/athena) | Explore, Agent | Query S3 data lakes via Athena using natural language |
 | [ClickHouse](/maestro/integrations/clickhouse) | Explore, Agent | Query ClickHouse databases using natural language |
+| [Databricks](/maestro/integrations/databricks) | Explore, Agent | Query Databricks SQL warehouses (Unity Catalog) using natural language |
 
 ## Service Integrations
 


### PR DESCRIPTION
Documents the new Databricks (SQL warehouses / Unity Catalog) integration.

- New `content/maestro/integrations/databricks.mdx` (overview, capabilities, settings/credentials, prerequisites, connection-details walkthrough, setup steps).
- Adds `databricks` to `_meta.ts` and the Data Sources table in `integrations/index.mdx`.

Companion to cardinalhq/conductor#675.