### PR TITLE
lakerunner/sizing: query sizing calculator from usage signals

### DIFF
--- a/components/QuerySizingEstimator.module.css
+++ b/components/QuerySizingEstimator.module.css
@@ -1,0 +1,339 @@
+.estimator {
+  margin: 2rem 0;
+}
+
+.privacyNote {
+  text-align: center;
+  font-size: 0.95rem;
+  color: #2e7d32;
+  margin-bottom: 2rem;
+  padding: 1rem 1.5rem;
+  background: rgba(76, 175, 80, 0.1);
+  border-radius: 8px;
+  border: 2px solid rgba(76, 175, 80, 0.3);
+  font-weight: 500;
+}
+
+:global(.dark) .privacyNote {
+  background: rgba(76, 175, 80, 0.15);
+  border-color: rgba(76, 175, 80, 0.4);
+  color: #81c784;
+}
+
+.section {
+  margin-bottom: 2rem;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+:global(.dark) .section {
+  background: rgba(255, 255, 255, 0.02);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.sectionTitle {
+  margin: 0 0 0.75rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+:global(.dark) .sectionTitle {
+  color: #e5e5e5;
+}
+
+.description {
+  margin: 0 0 1.25rem 0;
+  color: #666;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+:global(.dark) .description {
+  color: #999;
+}
+
+/* Primary input cards */
+.inputGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .inputGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.inputCard {
+  padding: 1rem;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+:global(.dark) .inputCard {
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+.inputLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+:global(.dark) .inputLabel {
+  color: #e5e5e5;
+}
+
+.inputField {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 1rem;
+  background: white;
+  color: #333;
+  box-sizing: border-box;
+}
+
+:global(.dark) .inputField {
+  background: #0a0a0a;
+  border-color: #444;
+  color: #e5e5e5;
+}
+
+.inputField:focus {
+  outline: none;
+  border-color: #ff5722;
+}
+
+.inputField::-webkit-inner-spin-button,
+.inputField::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.inputField[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.inputHint {
+  font-size: 0.75rem;
+  color: #888;
+  margin-top: 0.4rem;
+  display: block;
+}
+
+:global(.dark) .inputHint {
+  color: #777;
+}
+
+/* Advanced disclosure */
+.advancedToggle {
+  background: none;
+  border: none;
+  color: #ff5722;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.5rem 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.advancedToggle:hover {
+  text-decoration: underline;
+}
+
+.advancedCaret {
+  display: inline-block;
+  transition: transform 0.15s;
+}
+
+.advancedCaretOpen {
+  transform: rotate(90deg);
+}
+
+.advancedPanel {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: white;
+  border: 1px dashed #d0d0d0;
+  border-radius: 8px;
+}
+
+:global(.dark) .advancedPanel {
+  background: #1a1a1a;
+  border-color: #444;
+}
+
+.advancedGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.advancedItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.advancedItem label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #555;
+}
+
+:global(.dark) .advancedItem label {
+  color: #bbb;
+}
+
+.advancedItem .inputHint {
+  margin-top: 0;
+}
+
+/* Result tiles */
+.resultGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.resultTile {
+  padding: 1rem;
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  text-align: center;
+}
+
+:global(.dark) .resultTile {
+  background: #1a1a1a;
+  border-color: #333;
+}
+
+.resultTile.highlight {
+  border-color: #ff5722;
+  border-width: 2px;
+}
+
+.resultLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #888;
+  margin-bottom: 0.4rem;
+}
+
+:global(.dark) .resultLabel {
+  color: #999;
+}
+
+.resultValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #333;
+  font-variant-numeric: tabular-nums;
+}
+
+:global(.dark) .resultValue {
+  color: #e5e5e5;
+}
+
+.resultSub {
+  font-size: 0.78rem;
+  color: #888;
+  margin-top: 0.25rem;
+}
+
+:global(.dark) .resultSub {
+  color: #777;
+}
+
+/* Table */
+.tableWrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.table th,
+.table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e0e0e0;
+  white-space: nowrap;
+}
+
+:global(.dark) .table th,
+:global(.dark) .table td {
+  border-bottom-color: #333;
+}
+
+.table th {
+  font-weight: 600;
+  color: #555;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+:global(.dark) .table th {
+  color: #999;
+}
+
+.table td {
+  color: #333;
+  font-variant-numeric: tabular-nums;
+}
+
+:global(.dark) .table td {
+  color: #ddd;
+}
+
+.subRow td {
+  font-size: 0.8rem;
+  color: #777;
+  padding-left: 1.5rem;
+}
+
+:global(.dark) .subRow td {
+  color: #999;
+}
+
+/* Assumptions footer */
+.assumptions {
+  font-size: 0.8rem;
+  color: #666;
+  line-height: 1.5;
+}
+
+:global(.dark) .assumptions {
+  color: #999;
+}
+
+.assumptions ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.assumptions li {
+  margin-bottom: 0.25rem;
+}

--- a/components/QuerySizingEstimator.tsx
+++ b/components/QuerySizingEstimator.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import styles from './QuerySizingEstimator.module.css';
+import {
+  type QuerySizingInput,
+  QUERY_SIZING_DEFAULTS,
+  QUERY_GROUP_QPS_CAPACITY,
+  QUERY_POD_GROUP_SIZE,
+  QUERY_POD_CPU,
+  QUERY_POD_MEMORY_MI,
+  calculateQuerySizing,
+  formatCpu,
+  formatMemoryGi,
+} from '../lib/sizingCalculations';
+
+const parseNum = (v: string, fallback = 0): number => {
+  const n = parseFloat(v);
+  return isNaN(n) || n < 0 ? fallback : n;
+};
+
+const formatQps = (qps: number): string => qps.toFixed(qps < 1 ? 2 : 1);
+
+const formatUsd = (n: number): string =>
+  n.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+
+export default function QuerySizingEstimator() {
+  const [dashboards, setDashboards] = useState<string>('50');
+  const [alerts, setAlerts] = useState<string>('100');
+  const [engineers, setEngineers] = useState<string>('20');
+
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [alertEvalIntervalSec, setAlertEvalIntervalSec] = useState<string>(String(QUERY_SIZING_DEFAULTS.alertEvalIntervalSec));
+  const [panelsPerDashboard, setPanelsPerDashboard] = useState<string>(String(QUERY_SIZING_DEFAULTS.panelsPerDashboard));
+  const [panelRefreshSec, setPanelRefreshSec] = useState<string>(String(QUERY_SIZING_DEFAULTS.panelRefreshSec));
+  const [dashboardConcurrency, setDashboardConcurrency] = useState<string>(String(QUERY_SIZING_DEFAULTS.dashboardConcurrency));
+  const [adhocQueriesPerEngineerPerHour, setAdhoc] = useState<string>(String(QUERY_SIZING_DEFAULTS.adhocQueriesPerEngineerPerHour));
+  const [peakHoursPerDay, setPeakHoursPerDay] = useState<string>(String(QUERY_SIZING_DEFAULTS.peakHoursPerDay));
+  const [peakDaysPerWeek, setPeakDaysPerWeek] = useState<string>(String(QUERY_SIZING_DEFAULTS.peakDaysPerWeek));
+  const [costPerPodHourUsd, setCostPerPodHourUsd] = useState<string>(String(QUERY_SIZING_DEFAULTS.costPerPodHourUsd));
+  const [headroomFactor, setHeadroomFactor] = useState<string>(String(QUERY_SIZING_DEFAULTS.headroomFactor));
+  const [minPodGroups, setMinPodGroups] = useState<string>(String(QUERY_SIZING_DEFAULTS.minPodGroups));
+
+  const input: QuerySizingInput = useMemo(() => ({
+    dashboards: parseNum(dashboards),
+    alerts: parseNum(alerts),
+    engineers: parseNum(engineers),
+    alertEvalIntervalSec: parseNum(alertEvalIntervalSec, QUERY_SIZING_DEFAULTS.alertEvalIntervalSec) || QUERY_SIZING_DEFAULTS.alertEvalIntervalSec,
+    panelsPerDashboard: parseNum(panelsPerDashboard, QUERY_SIZING_DEFAULTS.panelsPerDashboard),
+    panelRefreshSec: parseNum(panelRefreshSec, QUERY_SIZING_DEFAULTS.panelRefreshSec) || QUERY_SIZING_DEFAULTS.panelRefreshSec,
+    dashboardConcurrency: parseNum(dashboardConcurrency, QUERY_SIZING_DEFAULTS.dashboardConcurrency),
+    adhocQueriesPerEngineerPerHour: parseNum(adhocQueriesPerEngineerPerHour, QUERY_SIZING_DEFAULTS.adhocQueriesPerEngineerPerHour),
+    peakHoursPerDay: parseNum(peakHoursPerDay, QUERY_SIZING_DEFAULTS.peakHoursPerDay),
+    peakDaysPerWeek: parseNum(peakDaysPerWeek, QUERY_SIZING_DEFAULTS.peakDaysPerWeek),
+    costPerPodHourUsd: parseNum(costPerPodHourUsd, QUERY_SIZING_DEFAULTS.costPerPodHourUsd),
+    headroomFactor: parseNum(headroomFactor, QUERY_SIZING_DEFAULTS.headroomFactor) || QUERY_SIZING_DEFAULTS.headroomFactor,
+    minPodGroups: parseNum(minPodGroups, QUERY_SIZING_DEFAULTS.minPodGroups) || QUERY_SIZING_DEFAULTS.minPodGroups,
+  }), [
+    dashboards, alerts, engineers,
+    alertEvalIntervalSec, panelsPerDashboard, panelRefreshSec,
+    dashboardConcurrency, adhocQueriesPerEngineerPerHour,
+    peakHoursPerDay, peakDaysPerWeek, costPerPodHourUsd,
+    headroomFactor, minPodGroups,
+  ]);
+
+  const r = useMemo(() => calculateQuerySizing(input), [input]);
+
+  return (
+    <div className={styles.estimator}>
+      <div className={styles.privacyNote}>
+        This calculator runs entirely in your browser. No data is sent to any server.
+      </div>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Your usage</h3>
+        <p className={styles.description}>
+          Three signals drive query load: how many dashboards are open during peak hours, how many alerts are
+          evaluating continuously, and how many engineers are running ad-hoc queries.
+        </p>
+
+        <div className={styles.inputGrid}>
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>Dashboards</label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={dashboards}
+              onChange={(e) => setDashboards(e.target.value)}
+              min="0"
+            />
+            <span className={styles.inputHint}>total dashboards defined</span>
+          </div>
+
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>Alerts</label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={alerts}
+              onChange={(e) => setAlerts(e.target.value)}
+              min="0"
+            />
+            <span className={styles.inputHint}>alert rules evaluating 24/7</span>
+          </div>
+
+          <div className={styles.inputCard}>
+            <label className={styles.inputLabel}>Engineers</label>
+            <input
+              type="number"
+              className={styles.inputField}
+              value={engineers}
+              onChange={(e) => setEngineers(e.target.value)}
+              min="0"
+            />
+            <span className={styles.inputHint}>people who query during business hours</span>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className={styles.advancedToggle}
+          onClick={() => setShowAdvanced(v => !v)}
+          aria-expanded={showAdvanced}
+        >
+          <span className={`${styles.advancedCaret} ${showAdvanced ? styles.advancedCaretOpen : ''}`}>▶</span>
+          {showAdvanced ? 'Hide assumptions' : 'Show assumptions'}
+        </button>
+
+        {showAdvanced && (
+          <div className={styles.advancedPanel}>
+            <div className={styles.advancedGrid}>
+              <div className={styles.advancedItem}>
+                <label>Alert eval interval (sec)</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={alertEvalIntervalSec}
+                  onChange={(e) => setAlertEvalIntervalSec(e.target.value)}
+                  min="1"
+                />
+                <span className={styles.inputHint}>how often each alert rule re-evaluates</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Panels per dashboard</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={panelsPerDashboard}
+                  onChange={(e) => setPanelsPerDashboard(e.target.value)}
+                  min="0"
+                />
+                <span className={styles.inputHint}>avg query-emitting panels</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Panel refresh (sec)</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={panelRefreshSec}
+                  onChange={(e) => setPanelRefreshSec(e.target.value)}
+                  min="1"
+                />
+                <span className={styles.inputHint}>dashboard auto-refresh interval</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Dashboards open per engineer (peak)</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={dashboardConcurrency}
+                  onChange={(e) => setDashboardConcurrency(e.target.value)}
+                  min="0"
+                  step="0.1"
+                />
+                <span className={styles.inputHint}>capped by total dashboards</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Ad-hoc queries / engineer / hr</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={adhocQueriesPerEngineerPerHour}
+                  onChange={(e) => setAdhoc(e.target.value)}
+                  min="0"
+                />
+                <span className={styles.inputHint}>during peak hours</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Peak hours / day</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={peakHoursPerDay}
+                  onChange={(e) => setPeakHoursPerDay(e.target.value)}
+                  min="0"
+                  max="24"
+                />
+                <span className={styles.inputHint}>business-hour window</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Peak days / week</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={peakDaysPerWeek}
+                  onChange={(e) => setPeakDaysPerWeek(e.target.value)}
+                  min="0"
+                  max="7"
+                />
+                <span className={styles.inputHint}>typically 5</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>$ / pod-hour</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={costPerPodHourUsd}
+                  onChange={(e) => setCostPerPodHourUsd(e.target.value)}
+                  min="0"
+                  step="0.01"
+                />
+                <span className={styles.inputHint}>2 vCPU + 4 GiB on-demand</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Headroom factor</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={headroomFactor}
+                  onChange={(e) => setHeadroomFactor(e.target.value)}
+                  min="1"
+                  step="0.1"
+                />
+                <span className={styles.inputHint}>multiplier for slow queries, retries, latency variance</span>
+              </div>
+
+              <div className={styles.advancedItem}>
+                <label>Min pod groups (HA)</label>
+                <input
+                  type="number"
+                  className={styles.inputField}
+                  value={minPodGroups}
+                  onChange={(e) => setMinPodGroups(e.target.value)}
+                  min="1"
+                  step="1"
+                />
+                <span className={styles.inputHint}>floor for HA across AZs</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Estimated load</h3>
+
+        <div className={styles.resultGrid}>
+          <div className={`${styles.resultTile} ${styles.highlight}`}>
+            <div className={styles.resultLabel}>Peak QPS</div>
+            <div className={styles.resultValue}>{formatQps(r.peakQps)}</div>
+            <div className={styles.resultSub}>business hours</div>
+          </div>
+          <div className={styles.resultTile}>
+            <div className={styles.resultLabel}>Off-peak QPS</div>
+            <div className={styles.resultValue}>{formatQps(r.offPeakQps)}</div>
+            <div className={styles.resultSub}>alerts only</div>
+          </div>
+          <div className={styles.resultTile}>
+            <div className={styles.resultLabel}>Peak pods</div>
+            <div className={styles.resultValue}>{r.peakPods}</div>
+            <div className={styles.resultSub}>{r.peakPods / QUERY_POD_GROUP_SIZE} × {QUERY_POD_GROUP_SIZE}-pod group</div>
+          </div>
+          <div className={styles.resultTile}>
+            <div className={styles.resultLabel}>Off-peak pods</div>
+            <div className={styles.resultValue}>{r.offPeakPods}</div>
+            <div className={styles.resultSub}>{r.offPeakPods / QUERY_POD_GROUP_SIZE} × {QUERY_POD_GROUP_SIZE}-pod group</div>
+          </div>
+          <div className={`${styles.resultTile} ${styles.highlight}`}>
+            <div className={styles.resultLabel}>Est. compute cost</div>
+            <div className={styles.resultValue}>{formatUsd(r.monthlyCostUsd)}</div>
+            <div className={styles.resultSub}>per month</div>
+          </div>
+        </div>
+
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Regime</th>
+                <th>QPS</th>
+                <th>Pods</th>
+                <th>vCPU</th>
+                <th>Memory</th>
+                <th>Hours / mo</th>
+                <th>Cost / mo</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Peak</strong> (business hours)</td>
+                <td>{formatQps(r.peakQps)}</td>
+                <td>{r.peakPods}</td>
+                <td>{formatCpu(r.peakCpu)}</td>
+                <td>{formatMemoryGi(r.peakMemoryMi)} Gi</td>
+                <td>{Math.round(r.peakHoursPerMonth)}</td>
+                <td>{formatUsd(r.peakMonthlyCostUsd)}</td>
+              </tr>
+              <tr className={styles.subRow}>
+                <td>alerts</td>
+                <td>{formatQps(r.alertQps)}</td>
+                <td colSpan={5}></td>
+              </tr>
+              <tr className={styles.subRow}>
+                <td>dashboards</td>
+                <td>{formatQps(r.dashboardQps)}</td>
+                <td colSpan={5}></td>
+              </tr>
+              <tr className={styles.subRow}>
+                <td>ad-hoc</td>
+                <td>{formatQps(r.adhocQps)}</td>
+                <td colSpan={5}></td>
+              </tr>
+              <tr>
+                <td><strong>Off-peak</strong> (alerts only)</td>
+                <td>{formatQps(r.offPeakQps)}</td>
+                <td>{r.offPeakPods}</td>
+                <td>{formatCpu(r.offPeakCpu)}</td>
+                <td>{formatMemoryGi(r.offPeakMemoryMi)} Gi</td>
+                <td>{Math.round(r.offPeakHoursPerMonth)}</td>
+                <td>{formatUsd(r.offPeakMonthlyCostUsd)}</td>
+              </tr>
+              <tr>
+                <td><strong>Total</strong></td>
+                <td colSpan={5}></td>
+                <td><strong>{formatUsd(r.monthlyCostUsd)}</strong></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>How this is computed</h3>
+        <div className={styles.assumptions}>
+          <p>Each pod is {QUERY_POD_CPU} vCPU + {formatMemoryGi(QUERY_POD_MEMORY_MI)} GiB. A {QUERY_POD_GROUP_SIZE}-pod group handles up to {QUERY_GROUP_QPS_CAPACITY} QPS at burst; we multiply expected QPS by a headroom factor (default {QUERY_SIZING_DEFAULTS.headroomFactor}×) to account for slow queries, retries, and latency variance, then round up to whole groups with a {QUERY_SIZING_DEFAULTS.minPodGroups}-group floor for HA across availability zones.</p>
+          <ul>
+            <li><strong>Alert QPS</strong> = alerts ÷ alert eval interval. Runs 24/7.</li>
+            <li><strong>Dashboard QPS</strong> = min(dashboards, engineers × concurrency) × panels ÷ panel refresh. Peak only.</li>
+            <li><strong>Ad-hoc QPS</strong> = engineers × queries per engineer per hour ÷ 3600. Peak only.</li>
+            <li><strong>Effective QPS</strong> = raw QPS × headroom factor; pod groups = max(min groups, ⌈effective QPS ÷ {QUERY_GROUP_QPS_CAPACITY}⌉).</li>
+            <li><strong>Cost</strong> = (peak pods × peak hours + off-peak pods × off-peak hours) × $/pod-hour, over a 4.345-week month.</li>
+          </ul>
+          <p>Defaults are calibrated to typical observability workloads; tune them under <em>Show assumptions</em> to match yours.</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/content/lakerunner/sizing.mdx
+++ b/content/lakerunner/sizing.mdx
@@ -1,4 +1,5 @@
 import SizingEstimator from '../../components/SizingEstimator';
+import QuerySizingEstimator from '../../components/QuerySizingEstimator';
 import SupportCallout from '../../components/SupportCallout';
 
 # Sizing Estimator
@@ -6,5 +7,13 @@ import SupportCallout from '../../components/SupportCallout';
 Use this calculator to estimate the compute resources (vCPU and memory) required for your Lakerunner deployment based on your expected telemetry throughput.
 
 <SizingEstimator />
+
+## Query sizing from usage
+
+The estimator above takes the number of query workers as a direct input. If you don't have a feel for that number yet, this calculator derives it from how your team uses the product — dashboards, alerts, and engineers — and estimates the compute cost across business and off-peak hours.
+
+The model assumes query pods scale down outside business hours, when only alert evaluation drives load. Pods are sized in 4-pod groups, where each group of 2-vCPU / 4-GiB pods handles up to 30 QPS.
+
+<QuerySizingEstimator />
 
 <SupportCallout />

--- a/lib/__tests__/querySizing.test.ts
+++ b/lib/__tests__/querySizing.test.ts
@@ -1,0 +1,157 @@
+import {
+  calculateQuerySizing,
+  QUERY_SIZING_DEFAULTS,
+  QUERY_POD_GROUP_SIZE,
+  QUERY_GROUP_QPS_CAPACITY,
+  type QuerySizingInput,
+} from '../sizingCalculations';
+
+function withDefaults(overrides: Partial<QuerySizingInput> & Pick<QuerySizingInput, 'dashboards' | 'alerts' | 'engineers'>): QuerySizingInput {
+  return { ...QUERY_SIZING_DEFAULTS, ...overrides };
+}
+
+describe('calculateQuerySizing — defaults shipped in the calculator', () => {
+  it('defaults bias toward conservative sizing: headroom 3, min 2 groups, dense dashboards', () => {
+    expect(QUERY_SIZING_DEFAULTS.headroomFactor).toBe(3.0);
+    expect(QUERY_SIZING_DEFAULTS.minPodGroups).toBe(2);
+    expect(QUERY_SIZING_DEFAULTS.panelsPerDashboard).toBe(12);
+    expect(QUERY_SIZING_DEFAULTS.panelRefreshSec).toBe(20);
+    expect(QUERY_SIZING_DEFAULTS.dashboardConcurrency).toBe(1.0);
+  });
+
+  it('small org (50/100/20) → constant 8 pods (HA floor binds)', () => {
+    const r = calculateQuerySizing(withDefaults({ dashboards: 50, alerts: 100, engineers: 20 }));
+
+    // alert QPS = 100/60 ≈ 1.67
+    expect(r.alertQps).toBeCloseTo(100 / 60, 3);
+    // concurrent dashboards = min(50, 20*1) = 20; dashboardQPS = 20*12/20 = 12
+    expect(r.dashboardQps).toBeCloseTo(12, 3);
+    // adhoc = 20*5/3600 ≈ 0.028
+    expect(r.adhocQps).toBeCloseTo(100 / 3600, 3);
+
+    // peak ≈ 13.7 QPS, off-peak ≈ 1.67 QPS
+    // With headroom 3.0, both regimes still way under 30 QPS per group → HA floor binds.
+    expect(r.peakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+    expect(r.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+  });
+
+  it('mid org (200/500/50) → peak crosses 90 QPS effective → 4 groups; off-peak at HA floor', () => {
+    const r = calculateQuerySizing(withDefaults({ dashboards: 200, alerts: 500, engineers: 50 }));
+
+    // alert QPS = 500/60 ≈ 8.33
+    expect(r.alertQps).toBeCloseTo(500 / 60, 2);
+    // concurrent = min(200, 50) = 50; dashboardQPS = 50*12/20 = 30
+    expect(r.dashboardQps).toBeCloseTo(30, 2);
+
+    // peak ≈ 38.4 QPS × 3 headroom = 115.2 → 4 groups (16 pods)
+    expect(r.peakPods).toBe(QUERY_POD_GROUP_SIZE * 4);
+    // off-peak 8.33 × 3 = 25 → 1 group, but min 2 groups
+    expect(r.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+  });
+
+  it('large org (500/1000/200) → 14 groups peak, 2 groups off-peak', () => {
+    const r = calculateQuerySizing(withDefaults({ dashboards: 500, alerts: 1000, engineers: 200 }));
+
+    // alert QPS = 1000/60 ≈ 16.67
+    expect(r.alertQps).toBeCloseTo(1000 / 60, 2);
+    // concurrent = min(500, 200) = 200; dashboardQPS = 200*12/20 = 120
+    expect(r.dashboardQps).toBeCloseTo(120, 2);
+
+    // peak ≈ 137 × 3 ≈ 411 → ceil(411/30) = 14 groups (56 pods)
+    expect(r.peakPods).toBe(QUERY_POD_GROUP_SIZE * 14);
+    // off-peak 16.67 × 3 = 50 → 2 groups (8 pods)
+    expect(r.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+  });
+
+  it('zero inputs → HA floor at both regimes (min 2 groups)', () => {
+    const r = calculateQuerySizing(withDefaults({ dashboards: 0, alerts: 0, engineers: 0 }));
+    expect(r.peakQps).toBe(0);
+    expect(r.offPeakQps).toBe(0);
+    expect(r.peakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+    expect(r.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+    expect(r.monthlyCostUsd).toBeGreaterThan(0);
+  });
+
+  it('headroomFactor multiplies effective QPS before group sizing', () => {
+    // alerts only → easy to reason about. 1000 alerts / 60 = 16.67 QPS.
+    // With headroom 1.0, that's < 30 → 1 group, min 2 = 2 groups.
+    const noHeadroom = calculateQuerySizing(withDefaults({
+      dashboards: 0, alerts: 1000, engineers: 0,
+      headroomFactor: 1.0, minPodGroups: 1,
+    }));
+    expect(noHeadroom.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 1);
+
+    // With headroom 2.0, that's 33.3 → 2 groups.
+    const x2 = calculateQuerySizing(withDefaults({
+      dashboards: 0, alerts: 1000, engineers: 0,
+      headroomFactor: 2.0, minPodGroups: 1,
+    }));
+    expect(x2.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+  });
+
+  it('minPodGroups enforces HA floor even at zero load', () => {
+    const r = calculateQuerySizing(withDefaults({
+      dashboards: 0, alerts: 0, engineers: 0,
+      headroomFactor: 1.0, minPodGroups: 3,
+    }));
+    expect(r.peakPods).toBe(QUERY_POD_GROUP_SIZE * 3);
+    expect(r.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 3);
+  });
+
+  it('crosses the 30-QPS-per-group threshold cleanly', () => {
+    const cap = QUERY_GROUP_QPS_CAPACITY;
+    // headroom 1.0, min 1 to isolate the group-boundary behavior.
+    // alerts = 60 * (cap - 1) ≈ just under 1 group with 60s interval
+    const justUnder = calculateQuerySizing(withDefaults({
+      dashboards: 0, alerts: 60 * (cap - 1), engineers: 0,
+      headroomFactor: 1.0, minPodGroups: 1,
+    }));
+    expect(justUnder.offPeakPods).toBe(QUERY_POD_GROUP_SIZE);
+
+    const justOver = calculateQuerySizing(withDefaults({
+      dashboards: 0, alerts: 60 * (cap + 1), engineers: 0,
+      headroomFactor: 1.0, minPodGroups: 1,
+    }));
+    expect(justOver.offPeakPods).toBe(QUERY_POD_GROUP_SIZE * 2);
+  });
+
+  it('hours per month: peak + off-peak ≈ 730.6 (24/7 coverage)', () => {
+    const r = calculateQuerySizing(withDefaults({ dashboards: 0, alerts: 0, engineers: 0 }));
+    expect(r.peakHoursPerMonth + r.offPeakHoursPerMonth).toBeCloseTo(168 * 4.345, 1);
+  });
+
+  it('custom alert interval scales alert QPS inversely', () => {
+    const fast = calculateQuerySizing(withDefaults({ dashboards: 0, alerts: 60, engineers: 0, alertEvalIntervalSec: 10 }));
+    const slow = calculateQuerySizing(withDefaults({ dashboards: 0, alerts: 60, engineers: 0, alertEvalIntervalSec: 60 }));
+    expect(fast.alertQps).toBeCloseTo(slow.alertQps * 6, 3);
+  });
+
+  it('cost scales linearly with $/pod-hour', () => {
+    const cheap = calculateQuerySizing(withDefaults({ dashboards: 100, alerts: 100, engineers: 50, costPerPodHourUsd: 0.06 }));
+    const pricey = calculateQuerySizing(withDefaults({ dashboards: 100, alerts: 100, engineers: 50, costPerPodHourUsd: 0.12 }));
+    expect(pricey.monthlyCostUsd).toBeCloseTo(cheap.monthlyCostUsd * 2, 2);
+  });
+
+  it('concurrentDashboards capped by dashboards count', () => {
+    // 1 dashboard, 1000 engineers → cap binds to 1
+    const r = calculateQuerySizing(withDefaults({ dashboards: 1, alerts: 0, engineers: 1000 }));
+    // dashboardQps = 1 * 12 / 20 = 0.6
+    expect(r.dashboardQps).toBeCloseTo(1 * 12 / 20, 3);
+  });
+
+  it('cost ballpark check on the documented scenarios (cost-per-pod-hour=$0.06)', () => {
+    const small = calculateQuerySizing(withDefaults({ dashboards: 50, alerts: 100, engineers: 20 }));
+    const mid = calculateQuerySizing(withDefaults({ dashboards: 200, alerts: 500, engineers: 50 }));
+    const large = calculateQuerySizing(withDefaults({ dashboards: 500, alerts: 1000, engineers: 200 }));
+
+    // Sanity bands so accidental regressions to the calc are visible.
+    expect(small.monthlyCostUsd).toBeGreaterThan(300);
+    expect(small.monthlyCostUsd).toBeLessThan(450);
+
+    expect(mid.monthlyCostUsd).toBeGreaterThan(400);
+    expect(mid.monthlyCostUsd).toBeLessThan(550);
+
+    expect(large.monthlyCostUsd).toBeGreaterThan(900);
+    expect(large.monthlyCostUsd).toBeLessThan(1100);
+  });
+});

--- a/lib/sizingCalculations.ts
+++ b/lib/sizingCalculations.ts
@@ -150,3 +150,131 @@ export function formatMemoryGi(mi: number): string {
 export function formatCpu(cpu: number): string {
   return cpu.toFixed(2);
 }
+
+// ---------------------------------------------------------------------------
+// Query sizing — derives QPS, pod groups, and monthly cost from usage signals.
+// ---------------------------------------------------------------------------
+
+// 4 pods @ 2 vCPU + 4 GiB each handle up to 30 QPS, so a "group" of 4 pods
+// is the unit we scale in. Each pod is 7.5 QPS; we round up to 4-pod groups
+// with a minimum of one group for HA.
+export const QUERY_POD_GROUP_SIZE = 4;
+export const QUERY_GROUP_QPS_CAPACITY = 30;
+export const QUERY_POD_CPU = 2;
+export const QUERY_POD_MEMORY_MI = 4096;
+
+export interface QuerySizingInput {
+  dashboards: number;
+  alerts: number;
+  engineers: number;
+
+  // Tunable assumptions (exposed in the UI as "Advanced").
+  alertEvalIntervalSec: number;          // how often each alert evaluates
+  panelsPerDashboard: number;            // avg query-emitting panels per dashboard
+  panelRefreshSec: number;               // dashboard panel auto-refresh interval
+  dashboardConcurrency: number;          // dashboards actively viewed per engineer at peak
+  adhocQueriesPerEngineerPerHour: number;
+  peakHoursPerDay: number;
+  peakDaysPerWeek: number;
+  costPerPodHourUsd: number;
+  headroomFactor: number;                // multiplier applied to QPS before sizing (slow queries, retries, latency variance)
+  minPodGroups: number;                  // minimum pod groups for HA, even at low QPS
+}
+
+export interface QuerySizingResult {
+  alertQps: number;
+  dashboardQps: number;
+  adhocQps: number;
+  peakQps: number;
+  offPeakQps: number;
+  peakPods: number;
+  offPeakPods: number;
+  peakHoursPerMonth: number;
+  offPeakHoursPerMonth: number;
+  monthlyCostUsd: number;
+  peakMonthlyCostUsd: number;
+  offPeakMonthlyCostUsd: number;
+  peakCpu: number;
+  peakMemoryMi: number;
+  offPeakCpu: number;
+  offPeakMemoryMi: number;
+}
+
+export const QUERY_SIZING_DEFAULTS: Omit<QuerySizingInput, 'dashboards' | 'alerts' | 'engineers'> = {
+  alertEvalIntervalSec: 60,
+  panelsPerDashboard: 12,
+  panelRefreshSec: 20,
+  dashboardConcurrency: 1.0,
+  adhocQueriesPerEngineerPerHour: 5,
+  peakHoursPerDay: 10,
+  peakDaysPerWeek: 5,
+  costPerPodHourUsd: 0.06,
+  headroomFactor: 3.0,
+  minPodGroups: 2,
+};
+
+const WEEKS_PER_MONTH = 4.345;
+const HOURS_PER_WEEK = 168;
+
+function podsForQps(qps: number, headroomFactor: number, minPodGroups: number): number {
+  const effectiveQps = Math.max(0, qps) * Math.max(0, headroomFactor);
+  const minGroups = Math.max(1, Math.floor(minPodGroups));
+  const groups = Math.max(minGroups, Math.ceil(effectiveQps / QUERY_GROUP_QPS_CAPACITY));
+  return groups * QUERY_POD_GROUP_SIZE;
+}
+
+export function calculateQuerySizing(input: QuerySizingInput): QuerySizingResult {
+  const dashboards = Math.max(0, input.dashboards);
+  const alerts = Math.max(0, input.alerts);
+  const engineers = Math.max(0, input.engineers);
+  const alertEvalIntervalSec = Math.max(1, input.alertEvalIntervalSec);
+  const panelsPerDashboard = Math.max(0, input.panelsPerDashboard);
+  const panelRefreshSec = Math.max(1, input.panelRefreshSec);
+  const dashboardConcurrency = Math.max(0, input.dashboardConcurrency);
+  const adhocPerHour = Math.max(0, input.adhocQueriesPerEngineerPerHour);
+  const peakHoursPerDay = Math.min(24, Math.max(0, input.peakHoursPerDay));
+  const peakDaysPerWeek = Math.min(7, Math.max(0, input.peakDaysPerWeek));
+  const costPerPodHourUsd = Math.max(0, input.costPerPodHourUsd);
+  const headroomFactor = Math.max(1, input.headroomFactor);
+  const minPodGroups = Math.max(1, Math.floor(input.minPodGroups));
+
+  const alertQps = alerts / alertEvalIntervalSec;
+
+  const concurrentDashboards = Math.min(dashboards, engineers * dashboardConcurrency);
+  const dashboardQps = (concurrentDashboards * panelsPerDashboard) / panelRefreshSec;
+
+  const adhocQps = (engineers * adhocPerHour) / 3600;
+
+  const peakQps = alertQps + dashboardQps + adhocQps;
+  const offPeakQps = alertQps;
+
+  const peakPods = podsForQps(peakQps, headroomFactor, minPodGroups);
+  const offPeakPods = podsForQps(offPeakQps, headroomFactor, minPodGroups);
+
+  const peakHoursPerWeek = Math.min(HOURS_PER_WEEK, peakHoursPerDay * peakDaysPerWeek);
+  const offPeakHoursPerWeek = HOURS_PER_WEEK - peakHoursPerWeek;
+  const peakHoursPerMonth = peakHoursPerWeek * WEEKS_PER_MONTH;
+  const offPeakHoursPerMonth = offPeakHoursPerWeek * WEEKS_PER_MONTH;
+
+  const peakMonthlyCostUsd = peakPods * peakHoursPerMonth * costPerPodHourUsd;
+  const offPeakMonthlyCostUsd = offPeakPods * offPeakHoursPerMonth * costPerPodHourUsd;
+
+  return {
+    alertQps,
+    dashboardQps,
+    adhocQps,
+    peakQps,
+    offPeakQps,
+    peakPods,
+    offPeakPods,
+    peakHoursPerMonth,
+    offPeakHoursPerMonth,
+    monthlyCostUsd: peakMonthlyCostUsd + offPeakMonthlyCostUsd,
+    peakMonthlyCostUsd,
+    offPeakMonthlyCostUsd,
+    peakCpu: peakPods * QUERY_POD_CPU,
+    peakMemoryMi: peakPods * QUERY_POD_MEMORY_MI,
+    offPeakCpu: offPeakPods * QUERY_POD_CPU,
+    offPeakMemoryMi: offPeakPods * QUERY_POD_MEMORY_MI,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a dynamic query sizing calculator to `content/lakerunner/sizing.mdx` that derives query QPS, pod count, and estimated monthly cost from three usage signals: number of dashboards, alerts, and engineers.

## Model

- **Alert QPS** runs 24/7: `alerts / alertEvalIntervalSec`
- **Dashboard QPS** runs at peak: `min(dashboards, engineers × concurrency) × panels / refresh`
- **Ad-hoc QPS** runs at peak: `engineers × queriesPerHour / 3600`
- Sizes in 4-pod groups at 30 QPS/group capacity, with a 3.0× **headroom factor** for query latency variance and a 2-group HA floor.
- Cost = `(peakPods × peakHours + offPeakPods × offPeakHours) × $/pod-hour` over a 4.345-week month.

All 8 tunables (alert interval, panels/dashboard, panel refresh, dashboard concurrency, ad-hoc rate, peak hours/day, peak days/week, $/pod-hour, headroom factor, min pod groups) are exposed under an **Advanced** disclosure. The 3 primary inputs (dashboards / alerts / engineers) drive sensible defaults.

## Worked examples (at defaults)

| Scenario | Inputs (dash / alerts / eng) | Peak pods | Off-peak pods | $/mo |
|---|---|---|---|---|
| Small | 50 / 100 / 20 | 8 | 8 | ~$350 |
| Mid | 200 / 500 / 50 | 16 | 8 | ~$455 |
| Large | 500 / 1000 / 200 | 56 | 8 | ~$975 |

## Files

- `lib/sizingCalculations.ts` — new `calculateQuerySizing`, `QuerySizingInput`, `QUERY_SIZING_DEFAULTS`
- `lib/__tests__/querySizing.test.ts` — 13 unit tests covering worked examples, headroom/floor behavior, boundary crossing, and cost-band sanity checks
- `components/QuerySizingEstimator.tsx` + CSS module — calculator UI matching the existing `SizingEstimator` style
- `content/lakerunner/sizing.mdx` — new "Query sizing from usage" section

## Test plan

- [x] `pnpm test` — 105/105 pass
- [x] `pnpm build` — clean production build
- [ ] Verify the new section renders correctly on the deployed preview
- [ ] Sanity-check that adjusting Advanced knobs visibly updates pods + cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)