### PR TITLE
fix(search): write Pagefind index to /_pagefind so Nextra loads it

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postbuild": "pagefind --site out",
+    "postbuild": "pagefind --site out --output-path out/_pagefind",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Problem
Search on docs.cardinalhq.io fails: `Failed to load search index — Failed to fetch dynamically imported module: /_pagefind/pagefind.js`.

## Cause
Nextra's search imports the index from the hardcoded path `/_pagefind/pagefind.js`, but `postbuild` ran `pagefind --site out` without `--output-path`, so Pagefind v1.4 wrote the bundle to `out/pagefind/` (no underscore). Deployed site served `/pagefind/*` while the UI requested `/_pagefind/*` → 404.

## Fix
`postbuild`: `pagefind --site out --output-path out/_pagefind`.

## Verified locally
Built and served `out/`: `/_pagefind/pagefind.js` → 200, `/_pagefind/pagefind-entry.json` → 200, old `/pagefind/pagefind.js` → 404. No `.nojekyll` needed (deploy-pages doesn't run Jekyll; site already serves `/_next/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)