### PR TITLE
docs(maestro): Agent Outcomes dashboard + compare feature page

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="accountSettings">
+    <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedRegions">
+      <list>
+        <option value="us-east-1" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/cardinal-docs.iml
+++ b/.idea/cardinal-docs.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,62 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <VueCodeStyleSettings>
+      <option name="INTERPOLATION_NEW_LINE_AFTER_START_DELIMITER" value="false" />
+      <option name="INTERPOLATION_NEW_LINE_BEFORE_END_DELIMITER" value="false" />
+    </VueCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Vue">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/copilot.data.migration.agent.xml
+++ b/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/cardinal-docs.iml" filepath="$PROJECT_DIR$/.idea/cardinal-docs.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/content/maestro/_meta.ts
+++ b/content/maestro/_meta.ts
@@ -6,4 +6,5 @@ export default {
   install: 'Installation',
   integrations: 'Integrations',
   'mcp-clients': 'Connect AI Clients',
+  'agent-outcomes': 'Agent Outcomes',
 }

--- a/content/maestro/agent-outcomes.mdx
+++ b/content/maestro/agent-outcomes.mdx
@@ -1,0 +1,46 @@
+import SupportCallout from '../../components/SupportCallout';
+
+# Agent Outcomes dashboard
+
+The Agent Outcomes dashboard answers two questions about your org's coding-agent spend: **what did it cost, and did the work ship?** Every Claude Code session run with the [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin) is attributed to an engineer, a git branch, a pull request, and an **initiative** (one branch = one initiative), then classified by outcome: **merged**, **in flight**, **lost** (closed or gone stale without merging), or **ad hoc** (research and diagnostic work that was never headed to a PR).
+
+It works the same on both deployments:
+
+- **Cardinal Cloud (SaaS)** — `app.cardinalhq.io`, under the Outcomes dashboard.
+- **Self-hosted Maestro** — the same dashboard on your Maestro host; session telemetry flows through your own Lakerunner.
+
+Members see their own sessions; org owners see everyone's.
+
+<SupportCallout />
+
+## Reading the dashboard
+
+The page is one scrolling view: a KPI strip (total spend, sessions, and the merged / in-flight / lost / ad-hoc split), spend-over-time with anomaly markers, an activity heatmap, then panels by user, initiative, repo, pull request, branch, and finally the full session ledger. Click any initiative, PR, or session to open its **case file** — a drawer with the spend breakdown, the chronological session ledger, and (for initiatives) an LLM-authored TL;DR of the specs its PRs touched.
+
+Two badges flag sessions worth a second look:
+
+- **`bloated`** — the session carried unusually heavy context per turn (cache-read tokens per tool call well above the fleet median). The tooltip shows the estimated dollars spent re-reading context above the baseline, and the fix: `/clear` between sub-tasks, or split the work into focused sessions.
+- **`⚠ drift`** — the session got expensive across unrelated bodies of work; a split would have been cheaper.
+
+## Comparing sessions and initiatives
+
+Anywhere you see a **⇄** button you can compare two entities side by side: on session rows, inside a session's case file (including one-click comparison against sibling sessions on the same branch), and on initiative rows. Click ⇄ once to arm the comparison, then pick the second entity; the result is a full-screen diff with a shareable URL.
+
+The diff is built from computed facts, not generated prose:
+
+- a **verdict line** ("B cost 4.3× A — most of the gap is context carried above the baseline"),
+- **decision triggers** — deterministic rules that fire only when a threshold is crossed, each showing the exact numbers it fired on and ending in an action (set a spend limit, `/clear` between themes, review a thrashing initiative before its next session),
+- an aligned **A | B | Δ ledger**, token-composition bars, and **theme lanes** showing where each session's dollars went (from stored session summaries),
+- for initiatives: **convergence lanes** (per-session cost bars up to the first merge) and a **"where the money went"** table of spend by theme across both initiatives.
+
+When the two sides aren't honestly comparable — different models, effort tiers, or a 10×+ scope difference — the diff says so in a banner rather than letting the totals mislead.
+
+## Spend limits
+
+Every panel has a gear (⚙) for spend-limit policies at four scopes: **session**, **initiative**, **engineer**, and **PR**, each with a window (day / week / month / lifetime) and an action (**notify**, **warn**, or **block**). Limits are evaluated as agent sessions run; the plugin surfaces warnings directly in Claude Code. Policies are owner-managed, and every limit records who set it. Compare-view triggers suggest caps where the data supports one (for example, a thrashing initiative gets a suggested cap of current spend +20%).
+
+## Requirements
+
+- The `cardinal-claude-plugin` installed in engineers' Claude Code environments (see [Connect AI clients](/maestro/mcp-clients)) — it attributes sessions to branches and initiatives. Branch names following `<type>/<kebab-name>` (`feat/`, `fix/`, `refactor/`, `infra/`, `research/`) classify the initiative type.
+- A connected **GitHub** integration, for PR outcome classification (merged / open / closed).
+- **Lakerunner**, which stores the session telemetry the dashboard reads.


### PR DESCRIPTION
First docs page for the Agent Outcomes dashboard (it was previously undocumented), covering outcome classification, case files, the bloated/drift badges, the new ⇄ compare feature (sessions + initiatives, decision triggers), and spend limits. Companion to conductor#1035/#1036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)