### PR TITLE
docs(lakerunner): add Claude Code skill install + usage page

### DIFF
--- a/content/lakerunner/claude-skill.mdx
+++ b/content/lakerunner/claude-skill.mdx
@@ -8,15 +8,17 @@ The Lakerunner CLI ships with a [Claude Code](https://docs.claude.com/en/docs/cl
 
 - [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) installed and working (`~/.claude` exists).
 - `lakerunner-cli` [installed](/lakerunner/cli#installation) and on your `PATH`.
-- `LAKERUNNER_QUERY_URL` and `LAKERUNNER_API_KEY` set in your environment.
+- Your Lakerunner deployment's query URL and an API key on hand — the installer will prompt for both. Ask whoever runs your Lakerunner deployment if you don't know them.
 
 ## Install
 
-Run the install script — it drops the skill into `~/.claude/skills/lakerunner-cli/`:
+Run the install script — it drops the skill into `~/.claude/skills/lakerunner-cli/` and prompts for credentials:
 
 ```bash copy
 curl -fsSL https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/scripts/install-claude-skill.sh | bash
 ```
+
+You'll be asked for `LAKERUNNER_QUERY_URL` and `LAKERUNNER_API_KEY` (the key input is hidden). The script then offers to append `export` lines to your shell profile (`~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish`) so the credentials are picked up in future shells. Decline and you'll get copy-pasteable exports instead. If either value is already set in your environment, the current value is offered as the default — press Enter to keep it.
 
 From a checkout of [`lakerunner-cli`](https://github.com/cardinalhq/lakerunner-cli), you can also run:
 
@@ -24,7 +26,7 @@ From a checkout of [`lakerunner-cli`](https://github.com/cardinalhq/lakerunner-c
 make install-skill
 ```
 
-Both paths do the same thing: create `~/.claude/skills/lakerunner-cli/SKILL.md`. To install into a non-default location, set `CLAUDE_SKILLS_DIR` before running the script.
+Both paths do the same thing: create `~/.claude/skills/lakerunner-cli/SKILL.md` and run the credential prompt. To install into a non-default location, set `CLAUDE_SKILLS_DIR` before running the script. In non-interactive contexts (e.g. piped installs without a TTY) the prompt is skipped and you'll be reminded to set the env vars yourself.
 
 ## Use
 


### PR DESCRIPTION
## Summary
- New page documenting the `lakerunner-cli` Claude Code skill: prerequisites, one-liner install, example prompts, guardrails, and uninstall.
- Wired into the Lakerunner sidebar next to CLI Reference.
- Reflects the current installer behavior: the script prompts for `LAKERUNNER_QUERY_URL` / `LAKERUNNER_API_KEY` and offers to persist them to the shell profile — users no longer need to export them by hand first.

## Test plan
- [ ] `pnpm dev` — page renders under `/lakerunner/claude-skill` and shows up in the sidebar.
- [ ] Follow the install one-liner end-to-end and confirm the prompt/persist flow matches the doc.