### PR TITLE
docs(lakerunner): nest Claude Code skill under CLI Reference

### DIFF
--- a/content/lakerunner/_meta.ts
+++ b/content/lakerunner/_meta.ts
@@ -8,7 +8,6 @@ export default {
   sizing: 'Sizing Estimator',
   architecture: 'Architecture',
   cli: 'CLI Reference',
-  'claude-skill': 'Claude Code Skill',
   'query-language': 'Query Language',
   'loki-comparison': 'Lakerunner vs. Loki',
 }

--- a/content/lakerunner/cli/_meta.ts
+++ b/content/lakerunner/cli/_meta.ts
@@ -1,0 +1,4 @@
+export default {
+  index: 'Overview',
+  'claude-skill': 'Claude Code Skill',
+}

--- a/content/lakerunner/cli/claude-skill.mdx
+++ b/content/lakerunner/cli/claude-skill.mdx
@@ -1,4 +1,4 @@
-import SupportCallout from '../../components/SupportCallout';
+import SupportCallout from '../../../components/SupportCallout';
 
 # Claude Code Skill
 

--- a/content/lakerunner/cli/index.mdx
+++ b/content/lakerunner/cli/index.mdx
@@ -1,4 +1,4 @@
-import SupportCallout from '../../components/SupportCallout';
+import SupportCallout from '../../../components/SupportCallout';
 
 # Lakerunner CLI
 


### PR DESCRIPTION
## Summary
- Move `cli.mdx` → `cli/index.mdx` and `claude-skill.mdx` → `cli/claude-skill.mdx`; the skill is a pure wrapper around the CLI, so it lives under it in the sidebar.
- Add `cli/_meta.ts` (`Overview` + `Claude Code Skill`) and drop `claude-skill` from the parent `_meta.ts`.
- `/lakerunner/cli` and its `#installation` anchor still resolve (the index page renders at the same path). The skill page moves from `/lakerunner/claude-skill` → `/lakerunner/cli/claude-skill`. The old page has only existed for minutes so there's no real bookmark surface to preserve; the lakerunner-cli README link will be updated in a follow-up PR.

## Test plan
- [ ] `pnpm dev` — sidebar shows "CLI Reference" with "Overview" and "Claude Code Skill" nested underneath.
- [ ] `/lakerunner/cli` renders the reference and its `#installation` anchor still jumps to the right heading.
- [ ] `/lakerunner/cli/claude-skill` renders the skill page.