### PR TITLE
docs(lakerunner): make CLI docs Windows-inclusive

### DIFF
--- a/content/lakerunner/cli/claude-skill.mdx
+++ b/content/lakerunner/cli/claude-skill.mdx
@@ -6,11 +6,13 @@ The Lakerunner CLI ships with a [Claude Code](https://docs.claude.com/en/docs/cl
 
 ## Prerequisites
 
-- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) installed and working (`~/.claude` exists).
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) installed and working. Claude Code stores its config under `~/.claude` on macOS/Linux and `%USERPROFILE%\.claude` on Windows.
 - `lakerunner-cli` [installed](/lakerunner/cli#installation) and on your `PATH`.
-- Your Lakerunner deployment's query URL and an API key on hand — the installer will prompt for both. Ask whoever runs your Lakerunner deployment if you don't know them.
+- Your Lakerunner deployment's query URL and an API key on hand — the installer will prompt for both on macOS/Linux (on Windows you'll set them yourself). Ask whoever runs your Lakerunner deployment if you don't know them.
 
 ## Install
+
+### macOS / Linux
 
 Run the install script — it drops the skill into `~/.claude/skills/lakerunner-cli/` and prompts for credentials:
 
@@ -27,6 +29,26 @@ make install-skill
 ```
 
 Both paths do the same thing: create `~/.claude/skills/lakerunner-cli/SKILL.md` and run the credential prompt. To install into a non-default location, set `CLAUDE_SKILLS_DIR` before running the script. In non-interactive contexts (e.g. piped installs without a TTY) the prompt is skipped and you'll be reminded to set the env vars yourself.
+
+### Windows
+
+The installer is a bash script, so on Windows you have two options.
+
+**Option A — WSL or Git Bash.** Run the install one-liner from a WSL/Git Bash shell exactly as shown for macOS/Linux above. The credentials will be persisted into that shell's profile; use the CLI from the same shell going forward.
+
+**Option B — Native PowerShell (manual install).** Fetch the skill file and set the environment variables yourself:
+
+```powershell copy
+$dest = "$env:USERPROFILE\.claude\skills\lakerunner-cli"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Invoke-WebRequest `
+  -Uri "https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/.claude/skills/lakerunner-cli/SKILL.md" `
+  -OutFile "$dest\SKILL.md"
+
+# Persist credentials for future shells (takes effect in new shells):
+setx LAKERUNNER_QUERY_URL "<your-lakerunner-query-url>"
+setx LAKERUNNER_API_KEY   "<your-api-key>"
+```
 
 ## Use
 
@@ -62,8 +84,16 @@ The skill source lives in the [`lakerunner-cli` repo](https://github.com/cardina
 
 ## Uninstall
 
+**macOS / Linux:**
+
 ```bash copy
 rm -rf ~/.claude/skills/lakerunner-cli
+```
+
+**Windows (PowerShell):**
+
+```powershell copy
+Remove-Item -Recurse -Force "$env:USERPROFILE\.claude\skills\lakerunner-cli"
 ```
 
 <SupportCallout />

--- a/content/lakerunner/cli/index.mdx
+++ b/content/lakerunner/cli/index.mdx
@@ -16,7 +16,9 @@ Grab the Lakerunner CLI from the [latest release](https://github.com/cardinalhq/
 | **Linux (arm64)** | `lakerunner-cli_Linux_arm64.tar.gz` |
 | **Windows (x86_64)** | `lakerunner-cli_Windows_x86_64.zip` |
 
-Unpack the archive, then move the `lakerunner-cli` binary to a location on your `PATH`:
+Unpack the archive, then move the `lakerunner-cli` binary to a location on your `PATH`.
+
+**macOS / Linux:**
 
 ```bash copy
 tar -xzf lakerunner-cli_Darwin_arm64.tar.gz
@@ -24,15 +26,40 @@ sudo mv lakerunner-cli /usr/local/bin/
 lakerunner-cli --help
 ```
 
+**Windows (PowerShell):**
+
+```powershell copy
+Expand-Archive .\lakerunner-cli_Windows_x86_64.zip -DestinationPath .
+# Move the binary somewhere on your PATH (create the folder if needed).
+Move-Item .\lakerunner-cli.exe "$env:USERPROFILE\bin\lakerunner-cli.exe"
+lakerunner-cli --help
+```
+
+Add `%USERPROFILE%\bin` to your PATH via **System Properties → Environment Variables** (or `setx PATH "$env:PATH;$env:USERPROFILE\bin"` in a new shell) if it isn't already.
+
 ## Configuration
 
 ### Environment Variables
 
-Set the following environment variables to connect the CLI to your Lakerunner instance:
+Set the following environment variables to connect the CLI to your Lakerunner instance.
+
+**macOS / Linux:**
 
 ```bash copy
 export LAKERUNNER_QUERY_URL=<your-lakerunner-query-url>
 export LAKERUNNER_API_KEY=<your-api-key>
+```
+
+**Windows (PowerShell):**
+
+```powershell copy
+# For the current session:
+$env:LAKERUNNER_QUERY_URL = "<your-lakerunner-query-url>"
+$env:LAKERUNNER_API_KEY   = "<your-api-key>"
+
+# To persist across sessions (takes effect in new shells):
+setx LAKERUNNER_QUERY_URL "<your-lakerunner-query-url>"
+setx LAKERUNNER_API_KEY   "<your-api-key>"
 ```
 
 | Variable | Description | Required |
@@ -280,7 +307,7 @@ lakerunner-cli aliases list
 
 1. **Download** the CLI from the [releases page](https://github.com/cardinalhq/lakerunner-cli/releases).
 
-2. **Configure** your environment:
+2. **Configure** your environment (see [Configuration](#environment-variables) for Windows PowerShell equivalents):
 
 ```bash copy
 export LAKERUNNER_QUERY_URL=<your-lakerunner-query-url>


### PR DESCRIPTION
## Summary
- The CLI Reference and Claude Code skill pages assumed macOS/Linux everywhere — tar/sudo mv, bash exports, curl|bash installer, rm -rf uninstall. Windows readers had no path forward.
- CLI Reference: PowerShell equivalents for unpacking the release zip, moving the binary onto PATH, and setting the two env vars (both session `$env:` and persistent `setx`).
- Claude Code Skill: reframe Install as macOS/Linux vs. Windows. Windows gets two paths — WSL/Git Bash (existing installer works) or native PowerShell (`Invoke-WebRequest` for `SKILL.md`, `setx` for creds). Uninstall covers both. Prereqs acknowledge `~/.claude` vs. `%USERPROFILE%\.claude`.

## Test plan
- [ ] `pnpm dev` — both pages render, PowerShell code blocks use the `powershell` highlighter.
- [ ] Windows user can follow the CLI Reference to install the binary and set env vars end-to-end.
- [ ] Windows user can follow the skill page's PowerShell option to install the skill without touching bash.