### PR TITLE
docs(lakerunner): promote Windows PowerShell installer to first-class

### DIFF
--- a/content/lakerunner/cli/claude-skill.mdx
+++ b/content/lakerunner/cli/claude-skill.mdx
@@ -8,7 +8,7 @@ The Lakerunner CLI ships with a [Claude Code](https://docs.claude.com/en/docs/cl
 
 - [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) installed and working. Claude Code stores its config under `~/.claude` on macOS/Linux and `%USERPROFILE%\.claude` on Windows.
 - `lakerunner-cli` [installed](/lakerunner/cli#installation) and on your `PATH`.
-- Your Lakerunner deployment's query URL and an API key on hand — the installer will prompt for both on macOS/Linux (on Windows you'll set them yourself). Ask whoever runs your Lakerunner deployment if you don't know them.
+- Your Lakerunner deployment's query URL and an API key on hand — the installer will prompt for both. Ask whoever runs your Lakerunner deployment if you don't know them.
 
 ## Install
 
@@ -32,23 +32,21 @@ Both paths do the same thing: create `~/.claude/skills/lakerunner-cli/SKILL.md` 
 
 ### Windows
 
-The installer is a bash script, so on Windows you have two options.
-
-**Option A — WSL or Git Bash.** Run the install one-liner from a WSL/Git Bash shell exactly as shown for macOS/Linux above. The credentials will be persisted into that shell's profile; use the CLI from the same shell going forward.
-
-**Option B — Native PowerShell (manual install).** Fetch the skill file and set the environment variables yourself:
+Run the PowerShell installer — it drops the skill into `%USERPROFILE%\.claude\skills\lakerunner-cli\` and prompts for credentials:
 
 ```powershell copy
-$dest = "$env:USERPROFILE\.claude\skills\lakerunner-cli"
-New-Item -ItemType Directory -Force -Path $dest | Out-Null
-Invoke-WebRequest `
-  -Uri "https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/.claude/skills/lakerunner-cli/SKILL.md" `
-  -OutFile "$dest\SKILL.md"
-
-# Persist credentials for future shells (takes effect in new shells):
-setx LAKERUNNER_QUERY_URL "<your-lakerunner-query-url>"
-setx LAKERUNNER_API_KEY   "<your-api-key>"
+iex (irm https://raw.githubusercontent.com/cardinalhq/lakerunner-cli/main/scripts/install-claude-skill.ps1)
 ```
+
+You'll be asked for `LAKERUNNER_QUERY_URL` and `LAKERUNNER_API_KEY` (the key input is hidden). The script then offers to persist both to your user environment via `setx`, so future shells and other processes pick them up automatically. Decline and you'll get the `setx` commands to run yourself. If either value is already set in your environment, the current value is offered as the default — press Enter to keep it.
+
+From a checkout of [`lakerunner-cli`](https://github.com/cardinalhq/lakerunner-cli), you can also run:
+
+```powershell copy
+pwsh scripts\install-claude-skill.ps1
+```
+
+Works in both PowerShell 7+ (`pwsh`) and Windows PowerShell 5.1 (`powershell.exe`). To install into a non-default location, set `$env:CLAUDE_SKILLS_DIR` before running. In non-interactive contexts (e.g. running the script from CI) the prompt is skipped and you'll be reminded to set the env vars yourself.
 
 ## Use
 


### PR DESCRIPTION
## Summary
- Rewrites the skill page's Windows section from "WSL/Git Bash fallback OR manual PowerShell install" into the same shape as the macOS/Linux section: one-liner (iex + irm), a checkout-friendly variant (`pwsh scripts\...`), and the same notes about prompts, hidden key input, existing-value defaults, `CLAUDE_SKILLS_DIR`, and non-interactive fallback.
- Drops the "on Windows you'll set them yourself" caveat from Prerequisites — no longer true once the PowerShell installer exists.
- Pairs with cardinalhq/lakerunner-cli#24 which ships the installer.

## Test plan
- [ ] Wait until cardinalhq/lakerunner-cli#24 is on `main` so the `iex (irm ...)` URL serves the new script.
- [ ] `pnpm dev` — page renders, both platform sections read as peers, PowerShell code blocks highlight correctly.