### PR TITLE
docs: site detail Versions card (current vs desired)

### DIFF
--- a/content/maestro/updates.mdx
+++ b/content/maestro/updates.mdx
@@ -26,6 +26,12 @@ Below the card, the components table lists each component's deployed version
 against the newest available, along with registry/mirror status and the
 update history.
 
+Each site's detail page (**Sites → your site**) also shows a **Versions**
+card: per component, the version currently running on that site next to the
+version its release set targets, with the same status badge. Versions are
+reported by the site's Perch agent on its regular check-in, so a
+just-installed site may show **Not reported yet** for a few minutes.
+
 ## Upgrade modes
 
 Org owners choose one of three modes:


### PR DESCRIPTION
Documents the new per-site Versions card on the site detail page (current vs desired per component, reported by the perch-sync agent). Companion to cardinalhq/conductor's site-version-reporting PR and cardinalhq/perch#81.