### PR TITLE
docs(agent-outcomes): Claude Code + Codex CLI plugin install guides

### DIFF
--- a/content/maestro/agent-outcomes/_meta.ts
+++ b/content/maestro/agent-outcomes/_meta.ts
@@ -1,0 +1,5 @@
+export default {
+  index: 'Overview',
+  'install-claude-plugin': 'Install: Claude Code plugin',
+  'install-codex-plugin': 'Install: Codex CLI plugin',
+}

--- a/content/maestro/agent-outcomes/index.mdx
+++ b/content/maestro/agent-outcomes/index.mdx
@@ -1,0 +1,55 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Agent Outcomes dashboard
+
+The Agent Outcomes dashboard answers two questions about your org's coding-agent spend: **what did it cost, and did the work ship?** Every Claude Code session run with the [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin) — and every Codex CLI session run with the [`cardinal-codex-plugin`](https://github.com/cardinalhq/cardinal-codex-plugin) — is attributed to an engineer, a git branch, a pull request, and an **initiative** (one branch = one initiative), then classified by outcome: **merged**, **in flight**, **lost** (closed or gone stale without merging), or **ad hoc** (research and diagnostic work that was never headed to a PR).
+
+To get your sessions onto the dashboard, install the plugin for your agent:
+
+- [Install: Claude Code plugin](/maestro/agent-outcomes/install-claude-plugin)
+- [Install: Codex CLI plugin](/maestro/agent-outcomes/install-codex-plugin)
+
+It works the same on both deployments:
+
+- **Cardinal Cloud (SaaS)** — `app.cardinalhq.io`, under the Outcomes dashboard.
+- **Self-hosted Maestro** — the same dashboard on your Maestro host; session telemetry flows through your own Lakerunner.
+
+Members see their own sessions; org owners see everyone's.
+
+<SupportCallout />
+
+## Reading the dashboard
+
+The page is one scrolling view: a KPI strip (total spend, sessions, and the merged / in-flight / lost / ad-hoc split), spend-over-time with anomaly markers, an activity heatmap, then panels by user, initiative, repo, pull request, branch, and finally the full session ledger. Click any initiative, PR, or session to open its **case file** — a drawer with the spend breakdown, the chronological session ledger, and (for initiatives) an LLM-authored TL;DR of the specs its PRs touched.
+
+Two badges flag sessions worth a second look:
+
+- **`bloated`** — the session carried unusually heavy context per turn (cache-read tokens per tool call well above the fleet median). The tooltip shows the estimated dollars spent re-reading context above the baseline, and the fix: `/clear` between sub-tasks, or split the work into focused sessions.
+- **`⚠ drift`** — the session got expensive across unrelated bodies of work; a split would have been cheaper.
+
+## Comparing sessions and engineers
+
+Anywhere you see a **⇄** button you can compare two entities side by side: on session rows, inside a session's case file (including one-click comparison against sibling sessions on the same branch), on the per-user cards (owners only), and on an initiative's contributor rows (which opens the engineer diff pre-scoped to that initiative). Click ⇄ once to arm the comparison, then pick the second entity; the result is a full-screen diff with a shareable URL.
+
+The diff is built from computed facts, not generated prose:
+
+- a **verdict line** ("B cost 4.3× A — most of the gap is context carried above the baseline"),
+- **decision triggers** — deterministic rules that fire only when a threshold is crossed, each showing the exact numbers it fired on and ending in an action (set a spend limit, `/clear` between themes, write down an effort-tier policy),
+- an aligned **A | B | Δ ledger**, token-composition bars, and **theme lanes** showing where each session's dollars went (from stored session summaries),
+- an optional **narrative** section — an LLM translation of the numbers above it. It can only restate and corroborate: every sentence cites the facts or stored summaries it draws on, and uncited sentences are discarded server-side. When the stored work summaries weaken a fired trigger, the trigger card is visually demoted (never hidden).
+
+The **engineer diff** compares working styles, not workloads: median session cost, median context per turn, bloated-session rate with recoverable dollars, xhigh-effort spend share, and lost spend. A scope selector narrows both sides to a shared initiative or repo so totals become comparable too. Style rules only fire at **n ≥ 10 sessions per side** — below that the diff says which rules were suppressed instead of staying silent — and a **work-mix overlap** score flags when the two engineers simply do different kinds of work.
+
+When the two sides aren't honestly comparable — different models, effort tiers, a 10×+ scope difference, or low work-mix overlap — the diff says so in a banner rather than letting the totals mislead.
+
+There is deliberately no initiative-vs-initiative diff: two initiatives are single tasks with no shared denominator, so every delta just restates "the work was different." Initiative-level health renders directly on the initiative's case file instead — a **Spend health** section (thrashing, overhead spend, lost spend triggers, and the $ split by outcome state) and a **"where the money went"** table of spend by theme.
+
+## Spend limits
+
+Every panel has a gear (⚙) for spend-limit policies at four scopes: **session**, **initiative**, **engineer**, and **PR**, each with a window (day / week / month / lifetime) and an action (**notify**, **warn**, or **block**). Limits are evaluated as agent sessions run; the plugin surfaces warnings directly in Claude Code. Policies are owner-managed, and every limit records who set it. Compare-view triggers suggest caps where the data supports one (for example, a thrashing initiative gets a suggested cap of current spend +20%).
+
+## Requirements
+
+- The Cardinal plugin installed in engineers' agent environments — [`cardinal-claude-plugin`](/maestro/agent-outcomes/install-claude-plugin) for Claude Code, [`cardinal-codex-plugin`](/maestro/agent-outcomes/install-codex-plugin) for Codex CLI. The plugin attributes sessions to branches and initiatives; branch names following `<type>/<kebab-name>` (`feat/`, `fix/`, `refactor/`, `infra/`, `research/`) classify the initiative type.
+- A connected **GitHub** integration, for PR outcome classification (merged / open / closed).
+- **Lakerunner**, which stores the session telemetry the dashboard reads.

--- a/content/maestro/agent-outcomes/install-claude-plugin.mdx
+++ b/content/maestro/agent-outcomes/install-claude-plugin.mdx
@@ -1,0 +1,80 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Install the Claude Code plugin
+
+The [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin) is what puts your Claude Code sessions on the [Agent Outcomes dashboard](/maestro/agent-outcomes). One browser-approved consent wires up both halves:
+
+- **Telemetry** — your sessions stream to Cardinal, attributed to engineer, branch, PR, and initiative, with per-turn token and tool usage for the dashboard's cost and anti-pattern analysis.
+- **MCP tools** — a single `cardinal` MCP server appears in Claude Code, exposing whichever tools your org has integrations for (Lakerunner, GitHub, Jira, …). Pass `--telemetry-only` if you want the dashboard side without the tools.
+
+The plugin also delivers **session context and spend limits**: every session in a git repo receives the initiative branch-naming convention at start, and any [spend-limit policies](/maestro/agent-outcomes#spend-limits) your org has set are enforced in-session — quiet context at *notify*, a visible message at *warn*, a stopped turn at *block*.
+
+<SupportCallout />
+
+## Requirements
+
+- Claude Code with plugin support (any recent stable release).
+- Python 3.9+ on your `PATH` (the plugin's helpers run as Python scripts).
+- A Cardinal account on `app.cardinalhq.io`, or a self-hosted Maestro your operator has prepared (see [Connect AI clients](/maestro/mcp-clients)).
+
+## 1. Install
+
+```bash
+claude plugin marketplace add cardinalhq/cardinal-claude-plugin
+claude plugin install cardinal@cardinalhq-claude-plugin
+```
+
+## 2. Connect
+
+From inside Claude Code:
+
+```
+/cardinal:connect
+```
+
+The plugin prints a URL like `https://app.cardinalhq.io/connect?code=ABCD-EFGH`. Open it in your browser, sign in if you aren't already, pick the org to connect, and click **Approve**. The plugin picks up your consent within a few seconds and writes the config.
+
+For self-hosted Maestro, pass your host:
+
+```
+/cardinal:connect --host https://maestro.example.internal
+```
+
+Then **fully quit Claude Code** (`Cmd-Q` on macOS) and start a new session — the telemetry and MCP settings are read at process start.
+
+## 3. Verify
+
+From the new session:
+
+```
+/cardinal:status
+```
+
+You'll see the host, your org, both endpoints, key prefixes, and a reachability probe against each side. Run a session in any git repo and it appears on the Outcomes dashboard within a few minutes.
+
+## Variants
+
+```
+/cardinal:connect --telemetry-only      # Outcomes dashboard only; skip the MCP tools
+/cardinal:connect --rotate              # Mint fresh keys, overwrite an existing connection
+/cardinal:connect --host https://…      # Point at a self-hosted Maestro
+/cardinal:connect --no-tool-details     # Privacy opt-out — see below
+/cardinal:connect --dry-run             # Walk the consent flow, write nothing
+```
+
+## Getting attributed correctly
+
+Sessions are attributed to an **initiative** by branch name: `<type>/<kebab-name>`, where the type prefix is one of `feat`, `fix`, `refactor`, `infra`, `chore`, `research`, or `spike` (for example `feat/outcomes-observability` → initiative *outcomes-observability*, type *feature*). Sessions on `main`/`master`/`develop`/`trunk` are treated as research/scoping work. The plugin reminds Claude of this convention at the start of every session, so branches it cuts for you classify cleanly.
+
+## Privacy
+
+By default the plugin captures bash command lines and file paths so Cardinal can tell which repo and service a session worked on. The contents of your prompts and tool inputs/outputs are never captured. If your org's policy forbids command lines and paths too, connect with `--no-tool-details` — sessions still appear, but as `repo=unknown`.
+
+## Disconnect
+
+```
+/cardinal:disconnect                    # Remove everything the plugin added
+/cardinal:disconnect --keep-telemetry   # Keep the dashboard side, remove the MCP tools
+```
+
+Disconnect revokes the keys with Cardinal and removes only the plugin-owned settings; everything else in your Claude Code config is left as it was.

--- a/content/maestro/agent-outcomes/install-codex-plugin.mdx
+++ b/content/maestro/agent-outcomes/install-codex-plugin.mdx
@@ -1,0 +1,87 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Install the Codex CLI plugin
+
+The [`cardinal-codex-plugin`](https://github.com/cardinalhq/cardinal-codex-plugin) puts your OpenAI Codex CLI sessions on the [Agent Outcomes dashboard](/maestro/agent-outcomes), with the same one-consent setup as the Claude Code plugin:
+
+- **Telemetry** — your Codex sessions stream to Cardinal, attributed to engineer, branch, PR, and initiative, with per-turn token usage and a computed dollar cost per session.
+- **MCP tools** — a managed `cardinal` MCP server entry in your Codex config, exposing whichever tools your org has integrations for. Pass `--telemetry-only` to skip this side.
+
+Like the Claude Code plugin, it also delivers **session context and spend limits**: sessions in a git repo receive the initiative branch-naming convention at start, and org [spend-limit policies](/maestro/agent-outcomes#spend-limits) are enforced in-session — quiet context at *notify*, a visible message at *warn*, a stopped turn at *block*.
+
+<SupportCallout />
+
+## Requirements
+
+- A recent Codex CLI release (with MCP server and hooks support).
+- Python 3.11+ on your `PATH`.
+- A Cardinal account on `app.cardinalhq.io`, or a self-hosted Maestro your operator has prepared (see [Connect AI clients](/maestro/mcp-clients)).
+
+## 1. Install
+
+```bash
+codex plugin marketplace add cardinalhq/cardinal-codex-plugin
+codex plugin add cardinal-codex-plugin@cardinalhq-codex-plugin
+```
+
+## 2. Connect
+
+Ask Codex:
+
+```text
+Use cardinal-connect
+```
+
+The connect skill prints a URL like `https://app.cardinalhq.io/connect?code=ABCD-EFGH`. Open it in your browser, sign in if you aren't already, pick the org to connect, and click **Approve**. The plugin picks up your consent within a few seconds and writes:
+
+| File | What gets written |
+| --- | --- |
+| `~/.codex/config.toml` | A managed `[mcp_servers.cardinal]` entry. |
+| `~/.codex/hooks.json` | Managed Cardinal telemetry hook entries. |
+| `~/.codex/cardinal.json` | Non-secret connection state for status/disconnect. |
+| `~/.codex/cardinal-secrets.json` | Your minted keys, written mode `0600`. |
+
+For self-hosted Maestro, run the script directly with your host:
+
+```bash
+python3 scripts/cardinal-connect --host https://maestro.example.internal
+```
+
+Then **restart Codex** so it reloads the MCP and hook configuration, and trust the Cardinal hooks if Codex prompts you to.
+
+## 3. Verify
+
+Ask Codex:
+
+```text
+Use cardinal-status
+```
+
+You'll see the connected org, both endpoints, key prefixes, and a reachability probe against each side. Run a session in any git repo and it appears on the Outcomes dashboard within a few minutes.
+
+## Variants
+
+```bash
+python3 scripts/cardinal-connect --telemetry-only   # Outcomes dashboard only; skip the MCP tools
+python3 scripts/cardinal-connect --rotate           # Mint fresh keys, overwrite an existing connection
+python3 scripts/cardinal-connect --host https://…   # Point at a self-hosted Maestro
+python3 scripts/cardinal-connect --dry-run          # Walk the consent flow, write nothing
+```
+
+Upgrading from a version before 0.4.0? Re-run `cardinal-connect --rotate` once so the newer hooks are registered.
+
+## Getting attributed correctly
+
+Sessions are attributed to an **initiative** by branch name: `<type>/<kebab-name>`, where the type prefix is one of `feat`, `fix`, `refactor`, `infra`, `chore`, `research`, or `spike` (for example `fix/login-crash` → initiative *login-crash*, type *bugfix*). Sessions on `main`/`master`/`develop`/`trunk` are treated as research/scoping work. The plugin surfaces this convention to Codex at session start, so branches it cuts for you classify cleanly.
+
+## Privacy
+
+The plugin captures tool names, command lines, and file paths so Cardinal can tell which repo and service a session worked on, plus token counts and rate-limit standing for cost reporting. The contents of your prompts are never captured.
+
+## Disconnect
+
+```text
+Use cardinal-disconnect
+```
+
+This revokes your keys with Cardinal and removes the managed MCP entry, hooks, and local state. Everything else in your Codex config is left as it was.

--- a/content/maestro/mcp-clients.mdx
+++ b/content/maestro/mcp-clients.mdx
@@ -5,7 +5,7 @@ import SupportCallout from '../../components/SupportCallout';
 Cardinal exposes every connected integration (Lakerunner, GitHub, Jira, Kubernetes, Slack, ServiceNow, …) as Model Context Protocol tools through Maestro's built-in MCP gateway. This page covers wiring two clients up to your Maestro instance:
 
 - **Claude Code**, via the official [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin). One command installs the plugin, one more authorizes it in your browser, and your Claude Code session sees every Cardinal tool your org has configured.
-- **OpenAI Codex CLI**, by editing `~/.codex/config.toml` directly — there's no plugin for Codex yet.
+- **OpenAI Codex CLI**, via the official [`cardinal-codex-plugin`](https://github.com/cardinalhq/cardinal-codex-plugin) (see [Install: Codex CLI plugin](/maestro/agent-outcomes/install-codex-plugin)) — or by editing `~/.codex/config.toml` directly if the plugin isn't an option.
 
 Both clients work the same way against either deployment:
 
@@ -18,7 +18,7 @@ Both clients work the same way against either deployment:
 
 Skip this section if you're on Cardinal Cloud — your endpoint is `https://app.cardinalhq.io` and there's nothing to install on your side.
 
-For self-hosted Maestro you provision one shared API key that gates the MCP endpoint. The plugin signs in through your browser like the rest of Maestro, but Codex CLI and the manual setup below use this shared key directly.
+For self-hosted Maestro you provision one shared API key that gates the MCP endpoint. The plugins sign in through your browser like the rest of Maestro, but the manual setups below use this shared key directly.
 
 ### 1. Provision the API key
 
@@ -152,7 +152,9 @@ Disconnect revokes the keys with Cardinal and removes everything the plugin adde
 
 ## Codex CLI (manual MCP config)
 
-There's no plugin for Codex CLI yet, so you wire MCP up by hand. Codex keeps its config in `~/.codex/config.toml` and supports streamable-HTTP MCP servers with custom headers via the `env_http_headers` table.
+Most users should install the [`cardinal-codex-plugin`](/maestro/agent-outcomes/install-codex-plugin) instead — it configures MCP for you, keeps it in sync, and adds session telemetry for the Agent Outcomes dashboard. Use this manual path only when the plugin isn't an option.
+
+Codex keeps its config in `~/.codex/config.toml` and supports streamable-HTTP MCP servers with custom headers via the `env_http_headers` table.
 
 You'll need three values:
 


### PR DESCRIPTION
- Convert Agent Outcomes to a section: overview + per-agent install pages
- New: Install: Claude Code plugin (marketplace install, /cardinal:connect
  flow, variants, branch-naming attribution, privacy, disconnect)
- New: Install: Codex CLI plugin (same structure for cardinal-codex-plugin)
- mcp-clients: drop the stale 'no plugin for Codex yet' claims; point the
  manual Codex path at the plugin as the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
