### PR TITLE
docs(agent-outcomes): Cursor plugin install guide

### DIFF
--- a/content/lakerunner/index.mdx
+++ b/content/lakerunner/index.mdx
@@ -51,7 +51,7 @@ Before installing Lakerunner, ensure you have:
 
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) - Kubernetes CLI
 2. [Helm](https://helm.sh/docs/intro/install/) 3.14+ - Package manager for Kubernetes
-3. Kubernetes cluster 1.28+ (local or cloud) with a default StorageClass
+3. Kubernetes cluster 1.33+ (local or cloud) with a default StorageClass
 
 For **Production** deployments, you'll also need:
 - S3-compatible object storage with notification capability (S3, GCS, or Azure Blob)

--- a/content/lakerunner/install.mdx
+++ b/content/lakerunner/install.mdx
@@ -31,10 +31,19 @@ deployment.
 
 You'll need:
 
-- A **Kubernetes cluster** (1.28+) and `kubectl` / `helm` configured against it.
+- A **Kubernetes cluster** (1.33+) and `kubectl` / `helm` configured against it.
 - **Cluster-admin** authority on that cluster — the operator installs cluster-scoped RBAC.
 - A **default StorageClass** — Lakerunner keeps its telemetry on PersistentVolumes provisioned from it. If no
-  StorageClass is marked default, the install can't bind storage.
+  StorageClass is marked default, the install can't bind storage and PersistentVolumeClaims hang **Pending**
+  with no error surfaced.
+
+  > **EKS:** a fresh cluster needs the **EBS CSI driver addon** installed (e.g.
+  > `eksctl create cluster … --addons aws-ebs-csi-driver` with OIDC), and the `gp2` StorageClass it ships is
+  > **not marked default**. Check with `kubectl get storageclass` — if nothing shows `(default)`, run:
+  >
+  > ```bash
+  > kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true
+  > ```
 - **Outbound HTTPS** from the cluster to Cardinal. No inbound ports are opened.
 - A free Cardinal account at [app.cardinalhq.io](https://app.cardinalhq.io). Creating your first site starts a
   **60-day trial automatically — no credit card required**.
@@ -74,12 +83,24 @@ Cardinal generates a one-line `helm install` for your site. Run it against the t
 
 <ExpandableImage url="/lakerunner/install/04-install-perch.png" alt="Connect your cluster — the generated helm install command for Perch" imgStyle={{ maxWidth: '100%', borderRadius: 6 }} />
 
+> **Check your kubecontext first.** The command installs into whatever cluster `kubectl config current-context`
+> points at. If you work with multiple clusters, confirm the context — or pin it explicitly with
+> `--kube-context <name>` — before running the install.
+
 ```bash
 helm install perch oci://public.ecr.aws/cardinalhq.io/perch \
   --namespace perch-system --create-namespace \
   --set site.id=<your-site-id> \
   --set site.apiKey=<your-site-api-key>
 ```
+
+> **Seeing `403 … authorization token has expired` from `public.ecr.aws`?** Your machine has a stale cached
+> ECR token from an earlier authenticated pull. The registry allows anonymous pulls — clear the stale login and
+> retry:
+>
+> ```bash
+> helm registry logout public.ecr.aws
+> ```
 
 > **Security note:** the `--set site.apiKey=…` form embeds the site key on the command line, so it lands in your
 > shell history and is readable via `helm get values`. For a stricter install, pre-create the Secret yourself
@@ -143,6 +164,10 @@ your generated sign-in credentials:
 ```bash
 kubectl -n lakerunner port-forward svc/lr-<id>-maestro 4200:4200
 ```
+
+> Copy the command **exactly as shown in the UI** — the `lr-<id>-` prefix is per-component, and the namespace
+> contains several services with *different* ids (Lakerunner, the collector, the Cardinal UI). If you've lost
+> the page, find the right one with `kubectl -n lakerunner get svc | grep maestro`.
 
 Then open [http://localhost:4200](http://localhost:4200) and sign in with the email and password shown. From
 here you're querying your own cluster's logs, metrics, and traces through the on-prem Cardinal UI. Expose it

--- a/content/maestro/agent-outcomes/_meta.ts
+++ b/content/maestro/agent-outcomes/_meta.ts
@@ -2,4 +2,5 @@ export default {
   index: 'Overview',
   'install-claude-plugin': 'Install: Claude Code plugin',
   'install-codex-plugin': 'Install: Codex CLI plugin',
+  'install-cursor-plugin': 'Install: Cursor plugin',
 }

--- a/content/maestro/agent-outcomes/index.mdx
+++ b/content/maestro/agent-outcomes/index.mdx
@@ -2,12 +2,13 @@ import SupportCallout from '../../../components/SupportCallout';
 
 # Agent Outcomes dashboard
 
-The Agent Outcomes dashboard answers two questions about your org's coding-agent spend: **what did it cost, and did the work ship?** Every Claude Code session run with the [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin) — and every Codex CLI session run with the [`cardinal-codex-plugin`](https://github.com/cardinalhq/cardinal-codex-plugin) — is attributed to an engineer, a git branch, a pull request, and an **initiative** (one branch = one initiative), then classified by outcome: **merged**, **in flight**, **lost** (closed or gone stale without merging), or **ad hoc** (research and diagnostic work that was never headed to a PR).
+The Agent Outcomes dashboard answers two questions about your org's coding-agent spend: **what did it cost, and did the work ship?** Every Claude Code session run with the [`cardinal-claude-plugin`](https://github.com/cardinalhq/cardinal-claude-plugin), every Codex CLI session run with the [`cardinal-codex-plugin`](https://github.com/cardinalhq/cardinal-codex-plugin), and every Cursor session run with the [`cardinal-cursor-plugin`](https://github.com/cardinalhq/cardinal-cursor-plugin) is attributed to an engineer, a git branch, a pull request, and an **initiative** (one branch = one initiative), then classified by outcome: **merged**, **in flight**, **lost** (closed or gone stale without merging), or **ad hoc** (research and diagnostic work that was never headed to a PR).
 
 To get your sessions onto the dashboard, install the plugin for your agent:
 
 - [Install: Claude Code plugin](/maestro/agent-outcomes/install-claude-plugin)
 - [Install: Codex CLI plugin](/maestro/agent-outcomes/install-codex-plugin)
+- [Install: Cursor plugin](/maestro/agent-outcomes/install-cursor-plugin)
 
 It works the same on both deployments:
 
@@ -50,6 +51,6 @@ Every panel has a gear (⚙) for spend-limit policies at four scopes: **session*
 
 ## Requirements
 
-- The Cardinal plugin installed in engineers' agent environments — [`cardinal-claude-plugin`](/maestro/agent-outcomes/install-claude-plugin) for Claude Code, [`cardinal-codex-plugin`](/maestro/agent-outcomes/install-codex-plugin) for Codex CLI. The plugin attributes sessions to branches and initiatives; branch names following `<type>/<kebab-name>` (`feat/`, `fix/`, `refactor/`, `infra/`, `research/`) classify the initiative type.
+- The Cardinal plugin installed in engineers' agent environments — [`cardinal-claude-plugin`](/maestro/agent-outcomes/install-claude-plugin) for Claude Code, [`cardinal-codex-plugin`](/maestro/agent-outcomes/install-codex-plugin) for Codex CLI, or [`cardinal-cursor-plugin`](/maestro/agent-outcomes/install-cursor-plugin) for Cursor. The plugin attributes sessions to branches and initiatives; branch names following `<type>/<kebab-name>` (`feat/`, `fix/`, `refactor/`, `infra/`, `research/`) classify the initiative type.
 - A connected **GitHub** integration, for PR outcome classification (merged / open / closed).
 - **Lakerunner**, which stores the session telemetry the dashboard reads.

--- a/content/maestro/agent-outcomes/install-cursor-plugin.mdx
+++ b/content/maestro/agent-outcomes/install-cursor-plugin.mdx
@@ -1,0 +1,94 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Install the Cursor plugin
+
+The [`cardinal-cursor-plugin`](https://github.com/cardinalhq/cardinal-cursor-plugin) puts your Cursor sessions on the [Agent Outcomes dashboard](/maestro/agent-outcomes), matching the Claude Code and Codex CLI plugins:
+
+- **Telemetry** — your Cursor sessions stream to Cardinal, attributed to engineer, branch, PR, and initiative, with per-tool activity and subagent lifecycle events.
+- **MCP tools** — a managed `cardinal` MCP server entry in `~/.cursor/mcp.json`, exposing whichever tools your org has integrations for. Pass `--telemetry-only` to skip this side.
+
+Sessions in a git repo receive the initiative branch-naming convention at start, and org [spend-limit policies](/maestro/agent-outcomes#spend-limits) are enforced in-session — quiet context at *notify*, a visible block at *block*. Cursor's `beforeSubmitPrompt` hook has no allow-with-message channel, so *warn* falls back to notify (agent-only) by default; set `CARDINAL_CURSOR_STRICT_WARN=1` in your environment to escalate warn to a hard block instead.
+
+<SupportCallout />
+
+## Requirements
+
+- Cursor with hooks (v1) support.
+- Python 3.11+ on your `PATH`.
+- A Cardinal account on `app.cardinalhq.io`, or a self-hosted Maestro your operator has prepared (see [Connect AI clients](/maestro/mcp-clients)).
+
+## 1. Install
+
+Cursor doesn't have a plugin marketplace, so the install is a `git clone` + run:
+
+```bash
+git clone https://github.com/cardinalhq/cardinal-cursor-plugin.git ~/workspace/cardinal-cursor-plugin
+```
+
+## 2. Connect
+
+```bash
+python3 ~/workspace/cardinal-cursor-plugin/plugins/cardinal-cursor-plugin/scripts/cardinal-connect
+```
+
+The connect script prints a URL like `https://app.cardinalhq.io/connect?code=ABCD-EFGH`. Open it in your browser, sign in if you aren't already, pick the org to connect, and click **Approve**. The plugin picks up your consent within a few seconds and writes:
+
+| File | What gets written |
+| --- | --- |
+| `~/.cursor/mcp.json` | A managed `mcpServers.cardinal` entry (tagged `cardinalManaged: true`). |
+| `~/.cursor/hooks.json` | Managed Cardinal hook entries for `sessionStart`, `beforeSubmitPrompt`, `postToolUse`, `preCompact`, `stop`, and `subagentStop`. |
+| `~/.cursor/cardinal.json` | Non-secret connection state for status/disconnect. |
+| `~/.cursor/cardinal-secrets.json` | Your minted keys, written mode `0600`. |
+
+For self-hosted Maestro, add `--host`:
+
+```bash
+python3 scripts/cardinal-connect --host https://maestro.example.internal
+```
+
+Then **restart Cursor** so it reloads the MCP and hook configuration.
+
+## 3. Verify
+
+```bash
+python3 scripts/cardinal-status
+```
+
+You'll see the connected org, both endpoints, key prefixes, and a reachability probe against each side. Run a session in any git repo and it appears on the Outcomes dashboard within a few minutes.
+
+## Cloud agents
+
+Cursor cloud agents do **not** load `~/.cursor/hooks.json` or `~/.cursor/mcp.json` — cloud VMs have no access to your home directory. To send Cardinal telemetry from cloud-agent runs, install the plugin at the project level from inside your repo:
+
+```bash
+cd path/to/your/repo
+python3 /path/to/plugins/cardinal-cursor-plugin/scripts/cardinal-connect --project
+```
+
+This additionally writes `.cursor/mcp.json` and `.cursor/hooks.json` at the repo root. Commit both files so cloud agents pick them up. Note that Cursor cloud agents don't run `sessionStart`, `beforeSubmitPrompt`, or `stop` (per [Cursor's hooks docs](https://cursor.com/docs/hooks)), so the initiative-convention prompt and the spend gate don't run there. Tool-level telemetry (`postToolUse`, `subagentStop`, `preCompact`) does.
+
+## Variants
+
+```bash
+python3 scripts/cardinal-connect --telemetry-only   # Outcomes dashboard only; skip the MCP tools
+python3 scripts/cardinal-connect --rotate           # Mint fresh keys, overwrite an existing connection
+python3 scripts/cardinal-connect --project          # Also install at .cursor/ for cloud-agent coverage
+python3 scripts/cardinal-connect --host https://…   # Point at a self-hosted Maestro
+python3 scripts/cardinal-connect --dry-run          # Walk the consent flow, write nothing
+```
+
+## Getting attributed correctly
+
+Sessions are attributed to an **initiative** by branch name: `<type>/<kebab-name>`, where the type prefix is one of `feat`, `fix`, `refactor`, `infra`, `chore`, `research`, or `spike` (for example `fix/login-crash` → initiative *login-crash*, type *bugfix*). Sessions on `main`/`master`/`develop`/`trunk` are treated as research/scoping work. The plugin surfaces this convention to Cursor at session start, so branches it cuts for you classify cleanly.
+
+## Privacy
+
+The plugin captures tool names, command lines, and file paths so Cardinal can tell which repo and service a session worked on. The contents of your prompts are never captured. Per-model-call token counts are not currently emitted from Cursor sessions (Cursor's transcript format for that data is undocumented; see the [parity spec](https://github.com/cardinalhq/cardinal-cursor-plugin/blob/main/docs/specs/cursor-parity.md) for the open spike).
+
+## Disconnect
+
+```bash
+python3 scripts/cardinal-disconnect
+```
+
+This revokes your keys with Cardinal and removes the managed MCP entry, hooks, and local state at both `~/.cursor/` and (if you used `--project`) the repo root. Everything else in your Cursor config is left as it was.


### PR DESCRIPTION
## Summary

- New page: `content/maestro/agent-outcomes/install-cursor-plugin.mdx` — Cursor install guide mirroring the Claude/Codex ones
- Adds the entry to `_meta.ts`
- Overview `index.mdx` now lists all three plugins side-by-side

Backs the [`cardinal-cursor-plugin`](https://github.com/cardinalhq/cardinal-cursor-plugin) that just published v0.1.0.

## Cursor-specific bits the page covers

- No plugin marketplace on Cursor — install is `git clone` + `python3 scripts/cardinal-connect`.
- Cloud-agent coverage requires `--project` so `.cursor/{mcp,hooks}.json` land at the repo root (Cursor cloud VMs don't load `~/.cursor/`).
- Warn-band asymmetry: Cursor's `beforeSubmitPrompt` has no allow-with-message channel, so warn falls back to notify (agent-only) by default. Documented `CARDINAL_CURSOR_STRICT_WARN=1` to escalate warn → block.
- Per-model-call token telemetry (`api_request` / `cardinal.turn_usage`) not yet emitted — Cursor's transcript format for that data is undocumented; the spike is tracked in the plugin's [`cursor-parity.md`](https://github.com/cardinalhq/cardinal-cursor-plugin/blob/main/docs/specs/cursor-parity.md).

## Test plan

- [ ] \`pnpm dev\`, navigate to /maestro/agent-outcomes/install-cursor-plugin, confirm rendering
- [ ] Sidebar shows the three install pages side-by-side
- [ ] Links to install-cursor-plugin from index.mdx resolve