### PR TITLE
docs(omnigent-policy): verify connect executable + clarify --config path

### DIFF
--- a/content/maestro/agent-outcomes/install-omnigent-policy.mdx
+++ b/content/maestro/agent-outcomes/install-omnigent-policy.mdx
@@ -67,11 +67,22 @@ Sanity check the injection landed inside omnigent's venv (not a separate one —
 
 The printed path should be under omnigent's own environment (`~/.local/pipx/venvs/omnigent/lib/...` or `~/.local/share/uv/tools/omnigent/lib/...`).
 
+Then confirm the `cardinal-omnigent-connect` CLI itself landed on your `PATH` — this is what `--include-apps` (pipx) / `--with-executables-from` (uv) provides, and it's separate from the import check above:
+
+```bash
+command -v cardinal-omnigent-connect        # should print a path
+uv tool list                                # (uv) lists omnigent + its injected executables
+```
+
+If the import works but `command -v` finds nothing, you installed the policy correctly but skipped the executable flag — re-run the inject/install with `--include-apps` (pipx) or `--with-executables-from cardinal-omnigent-policy` (uv). (Note: the distribution is named `cardinal-omnigent-policy` but imports as `cardinal_omnigent`, and its `cardinal-agent-core` dependency imports as `cardinal_core` — the names above are correct.)
+
 ## 2. Connect
 
 ```bash
 cardinal-omnigent-connect --config ~/.omnigent/config.yaml
 ```
+
+`~/.omnigent/config.yaml` is omnigent's **default server config** — the file `omnigent server` reads on start and `omnigent config` edits. If your server runs with a custom `-c/--config` path, point `--config` at that file instead: connect merges its managed block into whichever config your server actually loads, so it must be the same one.
 
 The command prints a URL like `https://app.cardinalhq.io/connect?code=ABCD-EFGH`. Open it in your browser, sign in, pick the org, and click **Approve**. Once approved, connect mints an ingest credential, writes the state directory, and merges a `cardinalManaged`-tagged block into your server config.
 


### PR DESCRIPTION
## What

Fills two gaps in **Install: omnigent policy** (`content/maestro/agent-outcomes/install-omnigent-policy.mdx`) that surfaced while verifying a fresh `uv tool install omnigent --with cardinal-omnigent-policy --with-executables-from cardinal-omnigent-policy` install.

- **Verify the `cardinal-omnigent-connect` executable is on PATH.** The existing sanity check only tests the Python *import*; it does not catch a missing `--include-apps` / `--with-executables-from` flag. Added a `command -v cardinal-omnigent-connect` + `uv tool list` check, plus the fix if the CLI is missing.
- **Note the dist-name to import-name mapping** (`cardinal-omnigent-policy` imports as `cardinal_omnigent`, `cardinal-agent-core` imports as `cardinal_core`) so the import check is not mistaken for a failure.
- **Clarify the `--config` path.** State that `~/.omnigent/config.yaml` is omnigent's default server config, and to substitute a custom `-c/--config` path if the server runs with one.

## Why

The literal connect step (`cardinal-omnigent-connect --config ~/.omnigent/config.yaml`) was already documented, but nothing let a user confirm the install actually exposed the CLI or explained why that config path is the right one.

Docs-only; +11 lines, one file. Code fences balanced.
