### PR TITLE
deps: security fixes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 overrides:
   '@babel/core': '>=7.29.6'
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion: '>=5.0.7'
+  brace-expansion: '>=5.0.8 <6'
   dompurify: '>=3.4.12'
   lodash-es: '>=4.18.0'
   mermaid: '>=11.15.0'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18 <9'
   sharp: '>=0.35.0'
   uuid: '>=14.0.0'
   ws: '>=8.21.0'
@@ -1506,9 +1506,9 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5174,7 +5174,7 @@ snapshots:
       mathjax-full: 3.2.2
       react: 19.2.7
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7008,15 +7008,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,11 @@
 overrides:
   '@babel/core': '>=7.29.6'
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion: '>=5.0.7'
+  brace-expansion: '>=5.0.8 <6'
   dompurify: '>=3.4.12'
   lodash-es: '>=4.18.0'
   mermaid: '>=11.15.0'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.18 <9'
   sharp: '>=0.35.0'
   uuid: '>=14.0.0'
   ws: '>=8.21.0'


### PR DESCRIPTION
Bumps brace-expansion 5.0.8, postcss 8.5.18+. Closes Dependabot alerts.