### PR TITLE
analytics: add GA4 tag to docs

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Footer, Layout, Navbar } from 'nextra-theme-docs'
 import { Head } from 'nextra/components'
 import { getPageMap } from 'nextra/page-map'
 import { Figtree, JetBrains_Mono } from 'next/font/google'
+import Script from 'next/script'
 import 'nextra-theme-docs/style.css'
 import '../styles/globals.css'
 import type { ReactNode } from 'react'
@@ -37,6 +38,16 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
     >
       <Head />
       <body>
+        {/* Same GA4 stream as cardinalhq.io: docs is a subdomain, so one
+            stream keeps a visitor who crosses over as one user/session.
+            A second stream would split identity and self-refer. */}
+        <Script async src="https://www.googletagmanager.com/gtag/js?id=G-051X4VR1RL" />
+        <Script id="ga4">{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-051X4VR1RL');
+        `}</Script>
         <Layout
           navbar={
             <Navbar


### PR DESCRIPTION
Adds gtag.js to the root layout using `G-051X4VR1RL` — the same stream as cardinalhq.io.

docs is a subdomain, so GA4 writes the `_ga` cookie at the registrable domain and a visitor crossing from the marketing site stays one user in one session. A separate docs stream would split identity and make cardinalhq.io show up as a referrer. Break reports out by subdomain with the `hostname` dimension instead.

Verified against a real `pnpm build`: the tag is present in the static export on both `out/index.html` and nested pages.