### PR TITLE
seo: add sitemap.xml and robots.txt

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next'
+
+// required by `output: export`
+export const dynamic = 'force-static'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://docs.cardinalhq.io/sitemap.xml',
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,21 @@
+import { getPageMap } from 'nextra/page-map'
+import type { MetadataRoute } from 'next'
+
+const BASE = 'https://docs.cardinalhq.io'
+
+// required by `output: export`
+export const dynamic = 'force-static'
+
+type Item = { route?: string; children?: Item[] }
+
+function routes(items: Item[]): string[] {
+  return items.flatMap((i) => [
+    ...(i.route && !i.route.includes('[') ? [i.route] : []),
+    ...(i.children ? routes(i.children) : []),
+  ])
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const all = routes((await getPageMap()) as Item[])
+  return Array.from(new Set(all)).sort().map((route) => ({ url: BASE + route }))
+}


### PR DESCRIPTION
Next.js App Router native `sitemap.ts`/`robots.ts` — no new dependency.

- Routes derived from Nextra's page map (58 URLs, matches the pagefind index count).
- `dynamic = 'force-static'` required by `output: export`.
- Base URL `https://docs.cardinalhq.io`.

No lastmod/priority/changefreq — Google ignores the latter two, and lastmod needs git mtimes plumbed in.