### PR TITLE
docs: OSS cleanup + Impeccable product record

### DIFF
--- a/.impeccable/critique/2026-08-05T20-39-10Z__content-index-mdx.md
+++ b/.impeccable/critique/2026-08-05T20-39-10Z__content-index-mdx.md
@@ -1,0 +1,126 @@
+---
+target: docs home + shell
+total_score: 26
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+timestamp: 2026-08-05T20-39-10Z
+slug: content-index-mdx
+---
+⚠️ DEGRADED: single-context (three sub-agents ran but none delivered a report; transcripts unrecoverable — Assessment A re-run inline, Assessment B's detector output recovered from disk and re-verified)
+
+# Critique: Cardinal docs home + shell
+
+Target: `content/index.mdx` + `app/layout.tsx` (Nextra shell). Mode: **Read**.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Breadcrumbs, active sidebar state, "Last updated on", live TOC highlight all present. Nothing signals the Quick Start exists. |
+| 2 | Match System / Real World | 3 | Domain language is correct throughout; Cardinal-brand vs `lakerunner`-identifier split handled well. Home-page register misses the audience. |
+| 3 | User Control and Freedom | 3 | Standard docs nav, breadcrumbs, Copy-page control. Nothing traps the reader. |
+| 4 | Consistency and Standards | 2 | 113 distinct literal colors across 10 CSS modules, no shared token layer; DESIGN.md describes a different site entirely. |
+| 5 | Error Prevention | 2 | The home page's "Quick Start to get you going:" promises a link that does not exist — it actively misleads. |
+| 6 | Recognition Rather Than Recall | 2 | 130 sidebar `<li>` rendered on the home page; 15 flat Integrations siblings, 12 flat Data Lake siblings. The Quick Start is pure recall — hidden from nav, unlinked from body. |
+| 7 | Flexibility and Efficiency | 3 | ⌘K Pagefind search, Copy-page-as-markdown, full keyboard nav. Genuinely good for a returning reader. |
+| 8 | Aesthetic and Minimalist Design | 2 | The home page is not minimal, it is *empty*: 502 characters of body copy above a large dead zone. |
+| 9 | Error Recovery | 3 | 404 page uses plain language and carries the pre-hydration legacy-URL redirect. No search offered from the 404. |
+| 10 | Help and Documentation | 3 | It *is* the documentation; `SupportCallout` gives a real escape hatch with a real address. |
+| **Total** | | **26/40** | **Acceptable — significant improvements needed** |
+
+## Design Specificity Verdict
+
+**LLM assessment.** This is stock Nextra with a mascot and an orange variable. The Cardinal identity in this shell amounts to three gestures: the chip logo in the navbar, `--cardinal-accent` orange on links, and a 3px orange left-stripe on every `<h2>`. Strip those and nothing distinguishes it from any other Nextra site on the internet. That verdict is harsher on the shell than on the content — the interior pages (`/data-lake/install` in particular) are genuinely well-authored, with a clear recommendation callout, real prerequisites, and a numbered task TOC. The craft is in the MDX, not in the design system.
+
+Worth calling out honestly: the one deliberate brand gesture, the `<h2>` side-stripe in `styles/globals.css`, is a move the project's own DESIGN.md explicitly forbids ("Don't use side-stripe borders"). The detector independently flagged a `side-tab` warning. But DESIGN.md here is a byte-identical copy of the *marketing site's* record — dark-only, Tailwind, OKLCH tokens — describing a site this repo is not. The stripe is not really a violation; the design record is simply the wrong oracle. That is the finding.
+
+**Deterministic scan.** `detect.mjs` over `app content components mdx-components.tsx`: exit 2, **379 findings** — 378 advisory, 1 warning.
+
+| Rule | Count |
+|---|---|
+| `design-system-color` | 335 |
+| `design-system-font-size` | 22 |
+| `design-system-radius` | 21 |
+| `side-tab` | 1 |
+
+Concentrated in: `LakerunnerHelmValuesWizard.module.css` (123), `SizingEstimator.module.css` (92), `diagrams/Diagram.module.css` (63), `QuerySizingEstimator.module.css` (54).
+
+**Large-scale false positive, stated plainly.** Nearly all 379 are "outside DESIGN.md" — measured against a DESIGN.md that documents the marketing site. As *stated*, they are noise. Cross-referencing turns up the real signal underneath:
+
+- **113 distinct literal colors** across 10 CSS modules, against **6** shared tokens in `styles/globals.css`.
+- Dark-mode twins are hand-maintained per file. `diagrams/Diagram.module.css` carries 46 literal colors against 19 `.dark` blocks; `counters.module.css` has a literal color and **no** dark handling at all.
+
+So the colors are not broken in dark mode — I checked, they largely pair up. The defect is that theme correctness is maintained by hand in ten places with no shared vocabulary, which is how it *becomes* broken.
+
+**Visual overlays.** Not available. Assessment B reported a completed injection run on four pages before it was lost, but no overlay is live in a browser tab now and I will not claim one is.
+
+## Overall Impression
+
+The interior documentation is better than the front door by a wide margin. `/data-lake/install` knows exactly who it is talking to. The home page does not: 502 characters, a greeting emoji, a promise of a Quick Start that goes nowhere, and a heading that says "Cardinal Documentation" to a reader who already knows they are in the Cardinal documentation.
+
+The single biggest opportunity is the home page. It is the one surface where PRODUCT.md's two confirmed readers diverge — one is going to Data Lake install, the other to UI integrations — and right now it routes neither. It hands both a 130-item sidebar and wishes them luck.
+
+## What's Working
+
+1. **`/data-lake/install` is a model install page.** It opens with a recommendation ("We recommend the operator for every install"), names the alternative and its cost ("you own upgrades and monitoring"), then gates on real prerequisites before any command. That ordering respects a reader who is about to run helm against production.
+2. **Accessibility fundamentals are actually there.** Skip-to-content link, real `<main>` landmark, clean H1→H2 order, fonts resolving correctly to Figtree/JetBrains Mono. Not glamorous, quietly correct.
+3. **The reference ergonomics are strong.** ⌘K search, Copy-page-as-markdown (well-judged for a docs site whose readers pipe pages into coding agents), breadcrumbs, live TOC. Heuristic 7 is the site's best score for a reason.
+
+## Priority Issues
+
+**[P1] The home page breaks its own promise.**
+`content/index.mdx:7` reads "New to Cardinal? We've got you covered, with a simple Quick Start to get you going:" — and the colon is followed by an "Our Products" heading. There is no Quick Start link. `content/data-lake/_meta.ts` sets `quickstart: { display: 'hidden' }`, so the page exists at `/data-lake/quickstart`, is absent from the sidebar, and is unlinked from the body. It is unreachable except by typing the URL.
+*Why it matters:* the first promise the site makes to a first-time reader is one it does not keep, and the page best suited to PRODUCT.md's stated goal ("unblocked install, unaided") is orphaned.
+*Fix:* link the Quick Start from that sentence, or drop the promise. If Quick Start is the intended on-ramp, unhide it in `_meta.ts` and make it the primary call on the home page.
+*Suggested command:* `/impeccable clarify`
+
+**[P1] The home page routes nobody.**
+502 characters of body copy; the whole decision is two bullets in body-sized text under an H1 that says "Cardinal Documentation". PRODUCT.md names two readers with two different destinations; neither gets a path.
+*Why it matters:* the home page is where the two audiences split. Making that split invisible pushes the work onto a 130-item sidebar.
+*Fix:* make the two-product choice the largest thing on the page — two real entry cards with the reader's job on them ("Stand up the Data Lake in your cloud" / "Configure Cardinal UI integrations"), not link-colored list items. Add the third door for How-To Guides, which the body never mentions.
+*Suggested command:* `/impeccable layout`
+
+**[P1] The sidebar is a wall of options.**
+130 `<li>` rendered on the home page; ~22 visible at 1440×900. Integrations is a flat list of 15 siblings; Data Lake is a flat 12; UI Install is 7. All three top sections auto-expand.
+*Why it matters:* four-plus items per group exceeds working memory; at fifteen, a reader stops reading and starts ⌘F-ing. It fails the chunking, minimal-choices, and progressive-disclosure checks simultaneously.
+*Fix:* group Integrations by kind (Ticketing / Chat / Data Warehouse / Infrastructure) — 15 becomes 4 groups. Collapse non-active top-level sections by default so the home page does not render the Data Lake's full twelve.
+*Suggested command:* `/impeccable distill`
+
+**[P2] There is no docs design system, and DESIGN.md documents someone else's.**
+113 literal colors, 10 modules, 6 shared tokens, hand-maintained dark twins, `counters.module.css` with no dark handling.
+*Why it matters:* every new component starts by inventing a gray. The detector cannot help because its oracle describes a different site, so 379 findings are unreadable as signal.
+*Fix:* run `/impeccable document` to replace DESIGN.md with this repo's real system, then lift the recurring grays and radii into `styles/globals.css` tokens.
+*Suggested command:* `/impeccable document`
+
+**[P2] Home-page voice misses the confirmed reader.**
+"Hello, and welcome! 👋" and "We've got you covered" against a brand voice committed to "calm, precise, trustworthy — a senior engineer explaining something real," addressed to someone mid-install with a half-written values file.
+*Why it matters:* it is the one place the docs sound like a template rather than like Cardinal, and it is the first thing anyone reads.
+*Fix:* open with what the reader can do and where to go, in the register `/data-lake/install` already uses.
+*Suggested command:* `/impeccable clarify`
+
+## Persona Red Flags
+
+**Alex (Impatient Power User):** Lands on `/`, finds 502 characters and no command. The fastest real path — Quick Start — is hidden from the sidebar and unlinked, so Alex cannot find it even deliberately. Recovers via ⌘K, which works well; the home page contributed nothing. Copy-page-as-markdown is the one feature that will make Alex stay.
+
+**Jordan (Confused First-Timer):** Reads "a simple Quick Start to get you going:" carefully, as Jordan does, and finds nothing after the colon. Then must choose between "Cardinal UI" and "Cardinal Data Lake" from one-line descriptions, with no guidance on which they need or whether they need both. Sidebar offers 22 more choices. This is the abandonment point.
+
+**Casey (Distracted Mobile User):** Layout is genuinely responsive — no horizontal scroll, readable, sensible tap targets. But `content/index.mdx:14` says "Existing Cardinal customers can find more detailed documentation in the sidebar," and on a 390px viewport there *is* no sidebar; it is behind an unlabeled hamburger. The copy references a UI element that is not on screen.
+
+**Project persona — "Priya," the mid-install platform engineer (from PRODUCT.md):** Arrives from a search result deep in `/data-lake/`, not at `/`. For her the home page is irrelevant and the interior pages are strong — this is the reader the site actually serves well today. Her risk is the sidebar: with `Architecture`, `CLI Reference`, and `App Instrumentation` as peers of `Installation` in one flat twelve, the install path does not read as a path.
+
+## Minor Observations
+
+- "On This Page" on the home page lists exactly one entry ("Our Products") — a TOC with one item is visual noise; suppress it under a threshold.
+- The home page's dead zone is large: content ends near 550px, footer sits near 870px, on a 1021px document.
+- The `<h2>` left-stripe is applied globally in `article h2`, including on single-H2 pages like the home page, where it decorates rather than divides.
+- The `N` circle at bottom-left overlapping the theme-toggle label is the Next.js dev indicator, not a production defect — noted so it is not mistaken for one.
+- `content/index.mdx` never mentions How-To Guides, though it is one of four top-level sections.
+
+## Questions to Consider
+
+1. If a reader lands on `/` and leaves 8 seconds later having clicked exactly one thing, what should that thing have been? The page currently has no answer.
+2. Why is Quick Start hidden? If it is not good enough to show, why does the home page promise it — and if it is, why is it the only page in the tree that is unreachable by navigation?
+3. What would the sidebar look like if it were designed for someone who already knows what they want, rather than for completeness?
+4. The interior pages are markedly better than the shell. Is the shell worth designing at all, or should the home page simply become three doors and get out of the way?

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,207 @@
+---
+name: Cardinal Docs
+description: Dark control-room identity — blue-tinted ink canvas, one ember/amber signal, evidence-first, no hype.
+colors:
+  background: "oklch(0.16 0.014 265)"
+  foreground: "oklch(0.975 0.004 250)"
+  card: "oklch(0.205 0.018 265)"
+  card-foreground: "oklch(0.975 0.004 250)"
+  popover: "oklch(0.205 0.018 265)"
+  popover-foreground: "oklch(0.975 0.004 250)"
+  primary: "oklch(0.975 0.004 250)"
+  primary-foreground: "oklch(0.16 0.014 265)"
+  secondary: "oklch(0.25 0.02 265)"
+  secondary-foreground: "oklch(0.975 0.004 250)"
+  muted: "oklch(0.25 0.02 265)"
+  muted-foreground: "oklch(0.685 0.026 258)"
+  accent: "oklch(0.63 0.14 38)"
+  accent-foreground: "oklch(0.16 0.014 265)"
+  highlight: "oklch(0.79 0.155 72)"
+  mcp: "oklch(0.72 0.115 228)"
+  destructive: "oklch(0.645 0.2 27)"
+  destructive-foreground: "oklch(0.985 0 0)"
+  border: "oklch(0.288 0.021 265)"
+  input: "oklch(0.288 0.021 265)"
+  ring: "oklch(0.62 0.018 262)"
+  surface: "oklch(0.72 0.03 265 / 5%)"
+  surface-hover: "oklch(0.72 0.03 265 / 9%)"
+  hairline: "oklch(0.8 0.03 265 / 12%)"
+typography:
+  display:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "clamp(2.625rem, 5vw, 3.375rem)"
+    fontWeight: 800
+    lineHeight: 1.03
+    letterSpacing: "-0.018em"
+  headline:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "clamp(2rem, 4.5vw, 2.75rem)"
+    fontWeight: 600
+    lineHeight: 1.15
+    letterSpacing: "-0.02em"
+  title:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.25rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "-0.015em"
+  body:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.0625rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  small:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.9375rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+  fine:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.6875rem"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0.05em"
+  figure:
+    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "2.125rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "-0.02em"
+  mono-body:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  mono-small:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.75rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  mono-micro:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "0.625rem"
+    fontWeight: 600
+    lineHeight: 1.4
+    letterSpacing: "0.2em"
+rounded:
+  sm: "8px"
+  md: "10px"
+  lg: "12px"
+  xl: "16px"
+  full: "9999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+  xl: "48px"
+  section: "clamp(96px, 12vw, 160px)"
+components:
+  button-primary:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.accent-foreground}"
+    rounded: "{rounded.lg}"
+    padding: "8px 16px"
+  button-outline:
+    backgroundColor: "transparent"
+    borderColor: "{colors.foreground} at 25%"
+    textColor: "{colors.foreground}"
+    rounded: "{rounded.lg}"
+    padding: "8px 16px"
+  card:
+    backgroundColor: "{colors.card}"
+    borderColor: "{colors.border}"
+    textColor: "{colors.card-foreground}"
+    rounded: "{rounded.xl}"
+    padding: "24px"
+---
+
+# Design System: Cardinal Docs
+
+Source of truth for the values above: `src/index.css` (`:root` custom properties) and `tailwind.config.js`, which maps them to semantic Tailwind utilities (`bg-background`, `text-foreground`, `border-border`, `bg-surface`, `text-accent`, `text-muted-foreground`, `text-highlight`). Change the CSS var, not the utility.
+
+## 1. Overview
+
+**Creative North Star: "The Control Room, lights down, signal up"**
+
+The marketing site is the product's own identity carried to a public surface. Conductor/Maestro is a calm control room — cool near-neutral surfaces, one warm signal, evidence over adjectives. The website takes that same system and turns up the scale, not the volume: bigger type, more air, real product surfaces (the Agent Outcomes dashboard, evidence chains, outcome ledgers, live investigation) doing the persuading. A visitor should feel they are already looking at the product before they sign up.
+
+**Dark-first.** The page base is a blue-tinted ink canvas (`background`, L 0.16, hue 265). There is no light theme; pages open `bg-background text-foreground` and separate surfaces by lightness (`surface`, `card`) rather than by inverting.
+
+Anti-references from PRODUCT.md: no AI-hype gradient text, no legacy-vendor feature grids, no enterprise beige. Dark is the material here, but the neon-on-black terminal look is still rejected — the canvas is a tinted near-neutral, not pure black, and the signal is warm, not neon.
+
+## 2. Colors
+
+**The One Signal Rule (load-bearing).** `accent` (ember, hue 38) is the only saturated color that carries meaning: primary CTAs, links, focus rings, live/active state, hover marks. `highlight` (amber, hue 72) is its lighter sibling, reserved for emphasized words in headings (`.gradient-text`, `.text-signal`) and for machine-data chrome — badges and mono eyebrows over product surfaces. If accent or highlight is decorating rather than meaning, it is wrong. Status hues (green/amber/red) appear only in their semantic role — inside product imagery and outcome data, never as marketing flavor.
+
+**The Tinted-Neutral Rule.** Every neutral leans faintly cool (hue ~258–265, chroma ≤ 0.026). No warm neutrals — no cream, sand, paper, parchment anywhere. Cool tint + warm signal is the whole palette tension; don't split the difference.
+
+- Body text is `foreground` on every surface. `muted-foreground` is for genuinely secondary text only.
+- `surface` / `surface-hover` / `hairline` are translucent overlays — use them for panels that sit *on* the canvas; `card` is the opaque step for panels that must read as a distinct object.
+- `mcp` (cool blue, hue 228) is the tool-call color in product diagrams, chosen to contrast the warm LLM accent. It is a diagram token, not a brand color.
+- There is no site-wide chart ramp. Data visualization on marketing pages is hand-drawn SVG using the tokens above; if a real multi-series chart lands here, port the product's ramp then rather than inventing one.
+
+## 3. Typography
+
+**Figtree Variable** for everything except machine data; **JetBrains Mono** for machine data. Hierarchy comes from weight and size, never a third typeface. `font-optical-sizing: auto` globally; `text-wrap: balance` on h1–h3.
+
+- **Display** — hero statements only, at weight 800. Clamped 2.625→3.375rem: these heroes live in a half-width grid column, not full bleed, so the ceiling is set by the column rather than the viewport. Tracking floor -0.04em.
+- **Headline** — section openers.
+- **Title** — card and sub-section headings. There is no step between `title` and `headline`; a heading that wants "a bit bigger than title" is drift, not a role.
+- **Body** — marketing prose runs 17px/1.6, capped at 65–75ch. `body` sets this as the document default so markdown prose inherits the scale.
+- **Fine** — one step under `small`, for dense supporting text: pricing ranges, footnotes, the hero trust line.
+- **Figure** — large numeric data (prices, counters). Display-scale, but it reads as a measurement rather than a statement, so it sits below `headline`. Pair with `tabular-nums`.
+- **Mono** — strictly machine data: metric names, costs, PR numbers, log lines, install commands. On a marketing page this is a signature move: real telemetry rendered as telemetry. `mono-micro` is the chrome step — the uppercase tracked eyebrows and badges over product surfaces. It carries a 0.2em default; call sites may override tracking, and do (0.16–0.24em), but nothing below 10px.
+
+Use the ramp utilities (`text-display`, `text-title`, `text-fine`, `text-figure`, `text-mono-micro`), which carry size, leading, tracking, and weight as one treatment. A literal `text-[Npx]` is a signal that a role is missing from the ramp, not a licence to hand-tune past it.
+
+**No gradient text, ever.** `.gradient-text` and `.headline-ink` are historical names for what are now solid fills — keep them solid. Emphasis is weight, size, or a single highlight word.
+
+## 4. Elevation & Layout
+
+Tonal-first, shadow-minimal: surfaces separate by lightness steps and hairline borders, not by drop shadows. `shadow-whisper` and `shadow-seat` are the only shadows for content; heavier shadows (`shadow-2xl`) are reserved for genuinely floating layers — dropdowns and lightbox dialogs. Section rhythm comes from generous, *varied* vertical spacing (`spacing.section` as the baseline, compressed where sections are conversationally linked), not from divider lines or alternating stripes.
+
+Cards are rationed: product evidence (screenshots, outcome ledgers) sits directly on the canvas or in a single hairline-bordered frame, not in identical icon-heading-text card grids. Nested cards prohibited.
+
+## 5. Components
+
+- **Buttons:** `rounded-lg`, `px-4 py-2`, `text-sm font-medium`. Primary = `bg-accent text-accent-foreground`, hover `opacity-90`. Outline = `border-foreground/25`, hover fills to accent (`hover:border-accent hover:bg-accent hover:text-accent-foreground`).
+- **Focus:** global `:focus-visible` is a 2px accent outline at 3px offset. Don't remove it without replacing it with an equally visible ring.
+- **Badges:** full-radius pills with soft tint fills (`border-highlight/60 bg-highlight/[0.14] text-highlight`), mono, uppercase, wide tracking — never loud solids.
+- **Navigation:** slim top bar on the canvas; active/hover marked with accent; no mega-menus.
+- **Product imagery:** real Conductor UI screenshots on a `rounded-xl` `border-border` frame over `bg-card/40`; click-to-zoom opens a `<dialog>` lightbox with a blurred `bg-background/85` backdrop.
+
+## 6. Motion
+
+Calm and intentional, matching "calm, precise, trustworthy":
+
+- Ease-out exponential curves only (`cubic-bezier(0.16, 1, 0.3, 1)`); no bounce, no elastic.
+- Content is visible by default; `.reveal` / `.animate-fade-in` are short fade-and-rise enhancements, never gates on visibility.
+- Signature moments — the live investigation, the NestForge DAG, the install terminal — may be alive, but as a bounded sequence, not an indefinite pulse.
+- The global `prefers-reduced-motion: reduce` block flattens all animations and transitions. Any JS-driven motion must check the same query itself; the CSS block can't reach it.
+
+## 7. Do's and Don'ts
+
+### Do:
+- **Do** let real product surfaces and real-shaped data make the claims — evidence over adjectives.
+- **Do** keep accent rare so the primary CTA is unmistakably *the* action on the page.
+- **Do** use JetBrains Mono to render telemetry as telemetry — it is the site's texture.
+- **Do** reach for the semantic tokens (`bg-surface`, `border-border`, `text-muted-foreground`) before writing a literal color.
+
+### Don't:
+- **Don't** use gradient text, sparkle iconography, or "revolutionize" energy — the calm is the differentiation.
+- **Don't** ship hero-metric cards, identical icon card grids, or uppercase tracked eyebrows on every section.
+- **Don't** use warm neutrals, pure #000, or neon-on-black.
+- **Don't** use side-stripe borders, nested cards, or content shadows heavier than `shadow-seat`.
+- **Don't** introduce a light-mode section; there is one canvas.
+- **Don't** reintroduce the retired light-theme tokens (`cobalt`, `ink`, `canvas`, `line`, `slate-*`, `ok`/`warn`/`bad`, `chart-1..5`). They were deleted from `tailwind.config.js` once the last consumer went; a literal color is a signal you want a semantic token that doesn't exist yet.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,207 +1,165 @@
 ---
 name: Cardinal Docs
-description: Dark control-room identity — blue-tinted ink canvas, one ember/amber signal, evidence-first, no hype.
+description: Nextra docs shell in both themes, carrying the Cardinal ember as the one signal — reference-first, terminal-adjacent, out of the reader's way.
 colors:
-  background: "oklch(0.16 0.014 265)"
-  foreground: "oklch(0.975 0.004 250)"
-  card: "oklch(0.205 0.018 265)"
-  card-foreground: "oklch(0.975 0.004 250)"
-  popover: "oklch(0.205 0.018 265)"
-  popover-foreground: "oklch(0.975 0.004 250)"
-  primary: "oklch(0.975 0.004 250)"
-  primary-foreground: "oklch(0.16 0.014 265)"
-  secondary: "oklch(0.25 0.02 265)"
-  secondary-foreground: "oklch(0.975 0.004 250)"
-  muted: "oklch(0.25 0.02 265)"
-  muted-foreground: "oklch(0.685 0.026 258)"
-  accent: "oklch(0.63 0.14 38)"
-  accent-foreground: "oklch(0.16 0.014 265)"
-  highlight: "oklch(0.79 0.155 72)"
-  mcp: "oklch(0.72 0.115 228)"
-  destructive: "oklch(0.645 0.2 27)"
-  destructive-foreground: "oklch(0.985 0 0)"
-  border: "oklch(0.288 0.021 265)"
-  input: "oklch(0.288 0.021 265)"
-  ring: "oklch(0.62 0.018 262)"
-  surface: "oklch(0.72 0.03 265 / 5%)"
-  surface-hover: "oklch(0.72 0.03 265 / 9%)"
-  hairline: "oklch(0.8 0.03 265 / 12%)"
+  cardinal-accent: "oklch(0.62 0.19 36)"
+  cardinal-accent-dark: "oklch(0.72 0.16 40)"
+  cardinal-accent-soft: "color-mix(in oklab, oklch(0.62 0.19 36) 18%, transparent)"
+  cardinal-accent-soft-dark: "color-mix(in oklab, oklch(0.72 0.16 40) 22%, transparent)"
+  cardinal-orange: "oklch(0.62 0.19 36)"
+  cardinal-orange-dark: "oklch(0.72 0.16 40)"
+  cardinal-red: "oklch(0.58 0.22 27)"
+  cardinal-red-dark: "oklch(0.68 0.19 27)"
+  cardinal-amber: "oklch(0.72 0.17 65)"
+  cardinal-amber-dark: "oklch(0.79 0.155 72)"
+  cardinal-gold: "oklch(0.79 0.155 72)"
+  cardinal-gold-dark: "oklch(0.84 0.14 78)"
 typography:
-  display:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "clamp(2.625rem, 5vw, 3.375rem)"
-    fontWeight: 800
-    lineHeight: 1.03
-    letterSpacing: "-0.018em"
-  headline:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "clamp(2rem, 4.5vw, 2.75rem)"
-    fontWeight: 600
-    lineHeight: 1.15
-    letterSpacing: "-0.02em"
+  body:
+    fontFamily: "Figtree, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.9rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
   title:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "1.25rem"
+    fontFamily: "Figtree, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.9rem"
     fontWeight: 600
     lineHeight: 1.3
-    letterSpacing: "-0.015em"
-  body:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "1.0625rem"
-    fontWeight: 400
-    lineHeight: 1.6
-    letterSpacing: "normal"
-  small:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.9375rem"
-    fontWeight: 400
-    lineHeight: 1.6
-    letterSpacing: "normal"
-  fine:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.8125rem"
-    fontWeight: 400
-    lineHeight: 1.5
     letterSpacing: "normal"
   label:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.6875rem"
-    fontWeight: 600
-    lineHeight: 1.2
-    letterSpacing: "0.05em"
-  figure:
-    fontFamily: "Figtree Variable, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "2.125rem"
-    fontWeight: 600
-    lineHeight: 1
-    letterSpacing: "-0.02em"
-  mono-body:
-    fontFamily: "JetBrains Mono, ui-monospace, monospace"
-    fontSize: "0.875rem"
+    fontFamily: "Figtree, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.85rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  small:
+    fontFamily: "Figtree, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.8rem"
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: "normal"
-  mono-small:
-    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+  fine:
+    fontFamily: "Figtree, ui-sans-serif, system-ui, sans-serif"
     fontSize: "0.75rem"
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: "normal"
-  mono-micro:
+  mono-body:
     fontFamily: "JetBrains Mono, ui-monospace, monospace"
-    fontSize: "0.625rem"
-    fontWeight: 600
-    lineHeight: 1.4
-    letterSpacing: "0.2em"
+    fontSize: "0.85rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
 rounded:
-  sm: "8px"
-  md: "10px"
+  sm: "6px"
+  md: "8px"
   lg: "12px"
-  xl: "16px"
-  full: "9999px"
-spacing:
-  xs: "4px"
-  sm: "8px"
-  md: "16px"
-  lg: "24px"
-  xl: "48px"
-  section: "clamp(96px, 12vw, 160px)"
+  circle: "50%"
+  full: "999px"
 components:
-  button-primary:
-    backgroundColor: "{colors.accent}"
-    textColor: "{colors.accent-foreground}"
-    rounded: "{rounded.lg}"
-    padding: "8px 16px"
-  button-outline:
-    backgroundColor: "transparent"
-    borderColor: "{colors.foreground} at 25%"
-    textColor: "{colors.foreground}"
-    rounded: "{rounded.lg}"
-    padding: "8px 16px"
-  card:
-    backgroundColor: "{colors.card}"
-    borderColor: "{colors.border}"
-    textColor: "{colors.card-foreground}"
-    rounded: "{rounded.xl}"
-    padding: "24px"
+  link:
+    textColor: "{colors.cardinal-accent}"
+  link-hover:
+    textColor: "{colors.cardinal-red}"
+  code-inline:
+    borderColor: "{colors.cardinal-accent-soft}"
+  control:
+    rounded: "{rounded.sm}"
+    typography: "{typography.label}"
+  panel:
+    rounded: "{rounded.md}"
+    typography: "{typography.body}"
 ---
 
 # Design System: Cardinal Docs
 
-Source of truth for the values above: `src/index.css` (`:root` custom properties) and `tailwind.config.js`, which maps them to semantic Tailwind utilities (`bg-background`, `text-foreground`, `border-border`, `bg-surface`, `text-accent`, `text-muted-foreground`, `text-highlight`). Change the CSS var, not the utility.
+Source of truth for the values above: `styles/globals.css`, which declares the `--cardinal-*` custom properties on `:root` and re-declares them under `.dark`. There is no Tailwind in this repo — the shell is `nextra-theme-docs`, and everything else is CSS Modules (`components/*.module.css`). Change the CSS var, not the call site.
+
+The tokens above are only what this repo actually declares — the accent family, the type steps its components use, and its radius scale. Canvas, body text, borders, and code-block color are deliberately absent because `nextra-theme-docs` owns them; they are not this repo's to define. The `-dark` suffixed color entries are the `.dark` re-declarations, listed so the pairing is machine-visible.
 
 ## 1. Overview
 
 **Creative North Star: "The Control Room, lights down, signal up"**
 
-The marketing site is the product's own identity carried to a public surface. Conductor/Maestro is a calm control room — cool near-neutral surfaces, one warm signal, evidence over adjectives. The website takes that same system and turns up the scale, not the volume: bigger type, more air, real product surfaces (the Agent Outcomes dashboard, evidence chains, outcome ledgers, live investigation) doing the persuading. A visitor should feel they are already looking at the product before they sign up.
+The docs are the same control room with the lights up. The marketing site argues; this site is read by someone mid-install with a terminal open beside it, so the identity is carried in details — the ember accent, the mono for machine data, the chip mark — while the reading surface stays out of the way. Where the marketing site turns up the scale, the docs turn it down: default type sizes, tight components, no hero anything.
 
-**Dark-first.** The page base is a blue-tinted ink canvas (`background`, L 0.16, hue 265). There is no light theme; pages open `bg-background text-foreground` and separate surfaces by lightness (`surface`, `card`) rather than by inverting.
+**Both themes, theme-agnostic.** Unlike the marketing site, this one has no single canvas. `nextra-theme-docs` owns background, text, border, and code-block colors in both light and dark, and the reader picks via the footer toggle. Nothing here may assume a dark base. Every color a component introduces needs its `.dark` counterpart in the same file, or it breaks for half the readers.
 
-Anti-references from PRODUCT.md: no AI-hype gradient text, no legacy-vendor feature grids, no enterprise beige. Dark is the material here, but the neon-on-black terminal look is still rejected — the canvas is a tinted near-neutral, not pure black, and the signal is warm, not neon.
+Anti-references, inherited: no AI-hype gradient text, no legacy-vendor feature grids, no enterprise beige, no neon-on-black terminal look. Added for docs: no marketing furniture on a reference page — no hero bands, no CTA cards, no testimonial pull-quotes between the reader and the command they came for.
 
 ## 2. Colors
 
-**The One Signal Rule (load-bearing).** `accent` (ember, hue 38) is the only saturated color that carries meaning: primary CTAs, links, focus rings, live/active state, hover marks. `highlight` (amber, hue 72) is its lighter sibling, reserved for emphasized words in headings (`.gradient-text`, `.text-signal`) and for machine-data chrome — badges and mono eyebrows over product surfaces. If accent or highlight is decorating rather than meaning, it is wrong. Status hues (green/amber/red) appear only in their semantic role — inside product imagery and outcome data, never as marketing flavor.
+**What is actually wired up.** `styles/globals.css` declares six variables — `--cardinal-orange`, `--cardinal-red`, `--cardinal-amber`, `--cardinal-gold`, `--cardinal-accent`, `--cardinal-accent-soft` — on `:root`, then re-declares all six under `.dark` at a higher lightness so the ember stays legible on Nextra's dark canvas. That per-theme pair is the pattern every color in this repo should follow.
 
-**The Tinted-Neutral Rule.** Every neutral leans faintly cool (hue ~258–265, chroma ≤ 0.026). No warm neutrals — no cream, sand, paper, parchment anywhere. Cool tint + warm signal is the whole palette tension; don't split the difference.
+**The One Signal Rule (load-bearing).** `--cardinal-accent` (ember) is the only saturated color that carries meaning: links, the `<h2>` rule, code-block borders, selection. Everything else on a docs page is Nextra's neutral. If the accent is decorating rather than meaning, it is wrong.
 
-- Body text is `foreground` on every surface. `muted-foreground` is for genuinely secondary text only.
-- `surface` / `surface-hover` / `hairline` are translucent overlays — use them for panels that sit *on* the canvas; `card` is the opaque step for panels that must read as a distinct object.
-- `mcp` (cool blue, hue 228) is the tool-call color in product diagrams, chosen to contrast the warm LLM accent. It is a diagram token, not a brand color.
-- There is no site-wide chart ramp. Data visualization on marketing pages is hand-drawn SVG using the tokens above; if a real multi-series chart lands here, port the product's ramp then rather than inventing one.
+**The Theme-Pair Rule.** Every color declared in this repo needs a `.dark` counterpart in the same file. There is no canvas to assume, and a value tuned for one theme is invisible or glaring in the other. `components/counters.module.css` is the standing violation: one literal color, no dark rule.
+
+**Known drift.** Against these 6 shared tokens the repo carries **113 distinct literal colors** across 10 CSS modules — a hand-copied gray scale (`#333`, `#e5e5e5`, `#999`, `#666`, `#1a1a1a`) plus a hardcoded `#ff5722` orange in 22 places that duplicates `--cardinal-accent` instead of referencing it. Heaviest: `LakerunnerHelmValuesWizard.module.css` (45), `diagrams/Diagram.module.css` (46 colors against only 19 dark rules), `SizingEstimator.module.css` (24). New work references the vars; consolidating the existing literals is tracked debt.
+
+- Canvas, body text, borders, and code-block colors belong to `nextra-theme-docs`. Don't restate them.
+- Status hues (green/amber/red) appear only in their semantic role inside diagrams and estimator output, never as flavor.
+- There is no chart ramp. Diagrams are hand-drawn SVG/CSS in `components/diagrams/`; if a real multi-series chart lands here, port the product's ramp rather than inventing one.
 
 ## 3. Typography
 
-**Figtree Variable** for everything except machine data; **JetBrains Mono** for machine data. Hierarchy comes from weight and size, never a third typeface. `font-optical-sizing: auto` globally; `text-wrap: balance` on h1–h3.
+**Figtree** for everything except machine data; **JetBrains Mono** for machine data. Both load via `next/font/google` in `app/layout.tsx` and are exposed as `--font-sans` and `--font-mono`. `styles/globals.css` binds `--font-sans` to `html` and `--font-mono` to `code, pre, kbd, samp` — that binding is the whole typographic contract. Hierarchy comes from weight and size, never a third typeface.
 
-- **Display** — hero statements only, at weight 800. Clamped 2.625→3.375rem: these heroes live in a half-width grid column, not full bleed, so the ceiling is set by the column rather than the viewport. Tracking floor -0.04em.
-- **Headline** — section openers.
-- **Title** — card and sub-section headings. There is no step between `title` and `headline`; a heading that wants "a bit bigger than title" is drift, not a role.
-- **Body** — marketing prose runs 17px/1.6, capped at 65–75ch. `body` sets this as the document default so markdown prose inherits the scale.
-- **Fine** — one step under `small`, for dense supporting text: pricing ranges, footnotes, the hero trust line.
-- **Figure** — large numeric data (prices, counters). Display-scale, but it reads as a measurement rather than a statement, so it sits below `headline`. Pair with `tabular-nums`.
-- **Mono** — strictly machine data: metric names, costs, PR numbers, log lines, install commands. On a marketing page this is a signature move: real telemetry rendered as telemetry. `mono-micro` is the chrome step — the uppercase tracked eyebrows and badges over product surfaces. It carries a 0.2em default; call sites may override tracking, and do (0.16–0.24em), but nothing below 10px.
+**Nextra owns the prose scale.** Unlike the marketing site, this repo has no type ramp of its own: heading sizes, body measure, and code-block type all come from `nextra-theme-docs`. The marketing ramp's display roles (`display`, `headline`, `figure`, `mono-micro`) have no call sites here and are deliberately absent from the frontmatter — don't reach for them, and don't restyle Nextra's headings to reproduce them.
 
-Use the ramp utilities (`text-display`, `text-title`, `text-fine`, `text-figure`, `text-mono-micro`), which carry size, leading, tracking, and weight as one treatment. A literal `text-[Npx]` is a signal that a role is missing from the ramp, not a licence to hand-tune past it.
+What this repo actually sets is component type, inside `components/*.module.css`:
 
-**No gradient text, ever.** `.gradient-text` and `.headline-ink` are historical names for what are now solid fills — keep them solid. Emphasis is weight, size, or a single highlight word.
+- **Component body** — 0.9rem is the dominant step (18 uses), with 0.85rem (14) just under it for dense wizard rows and 0.8rem / 0.75rem for helper text.
+- **Component headings** — weight 600 is the default emphasis (22 uses), 500 for the softer step (14). Weights above 700 are one-offs and should not spread.
+- **Mono** — strictly machine data: metric names, log lines, install commands, generated YAML. On a docs page this is not a signature move, it is literal: the reader is going to copy it.
+
+**Do not hand-tune past the two steps.** The 0.9/0.85rem pair plus weight 500/600 covers essentially every component in the repo. A third size in a new module is drift unless it earns a documented role.
+
+**No gradient text, ever.** Emphasis is weight, size, or the accent color — never a gradient fill.
 
 ## 4. Elevation & Layout
 
-Tonal-first, shadow-minimal: surfaces separate by lightness steps and hairline borders, not by drop shadows. `shadow-whisper` and `shadow-seat` are the only shadows for content; heavier shadows (`shadow-2xl`) are reserved for genuinely floating layers — dropdowns and lightbox dialogs. Section rhythm comes from generous, *varied* vertical spacing (`spacing.section` as the baseline, compressed where sections are conversationally linked), not from divider lines or alternating stripes.
+Borders do the work, not shadows — and the code agrees: the entire repo carries **three** `box-shadow` declarations. Two are the same lifted-panel treatment written twice for the two themes (`0 18px 40px rgba(2, 6, 23, 0.6)` dark, `rgba(15, 23, 42, 0.12)` light); the third is a 2px error ring. Everything else separates by a 1px border and a background step. Keep it that way: a new shadow needs a reason a border cannot serve.
 
-Cards are rationed: product evidence (screenshots, outcome ledgers) sits directly on the canvas or in a single hairline-bordered frame, not in identical icon-heading-text card grids. Nested cards prohibited.
+Layout is Nextra's: fixed sidebar, centered content column, right-hand TOC, and its own breakpoints. This repo does not set page rhythm — there is no `spacing.section` here. What it does set is the density *inside* components, and that density is tight: wizard rows, estimator tables, and connector cards are meant to be scanned beside a terminal, not scrolled through.
+
+Cards are rationed. The reference content is prose, code, and tables; a card is for a genuinely separable object (a connector, an estimator panel, a callout). Nested cards prohibited.
 
 ## 5. Components
 
-- **Buttons:** `rounded-lg`, `px-4 py-2`, `text-sm font-medium`. Primary = `bg-accent text-accent-foreground`, hover `opacity-90`. Outline = `border-foreground/25`, hover fills to accent (`hover:border-accent hover:bg-accent hover:text-accent-foreground`).
-- **Focus:** global `:focus-visible` is a 2px accent outline at 3px offset. Don't remove it without replacing it with an equally visible ring.
-- **Badges:** full-radius pills with soft tint fills (`border-highlight/60 bg-highlight/[0.14] text-highlight`), mono, uppercase, wide tracking — never loud solids.
-- **Navigation:** slim top bar on the canvas; active/hover marked with accent; no mega-menus.
-- **Product imagery:** real Conductor UI screenshots on a `rounded-xl` `border-border` frame over `bg-card/40`; click-to-zoom opens a `<dialog>` lightbox with a blurred `bg-background/85` backdrop.
+There is no button/badge component library here — Nextra supplies the shell, and this repo's components are documentation instruments. Radius is the one shared shape signal: **6px** (16 uses) for controls and small chrome, **8px** (14 uses) for panels and cards. `50%` for avatars/dots and `999px` for pills are the only sanctioned exceptions; the stray 1px/3px/5px/14px values in `HowTo.module.css` and `SizingEstimator.module.css` are drift.
+
+- **Links and headings:** `article a` is `var(--cardinal-accent)`, underline-free, hovering to `var(--cardinal-red)`. `article h2` carries the 3px accent side-rule. `article code` borders in `--cardinal-accent-soft`, and `::selection` fills with it. These four rules in `styles/globals.css` are the entire brand surface of a docs page.
+- **Navigation:** `nextra-theme-docs` owns it — navbar with the chip mark, collapsible sidebar from `_meta.ts`, right-hand TOC, ⌘K Pagefind search. Don't hand-roll nav; change `_meta.ts`.
+- **Interactive instruments** (`LakerunnerHelmValuesWizard`, `CollectorManifestsWizard`, `SizingEstimator`, `QuerySizingEstimator`, `QuickStartSteps`): these are the signature components. They are forms whose output the reader pastes into production, so correctness of the generated text outranks every visual consideration. Label every control, keep them keyboard-operable, and never let styling obscure which value is live.
+- **Product imagery:** `ExpandableImage` — click-to-zoom into a fixed `rgba(0,0,0,0.8)` overlay at `z-index: 9999`. Known gap: it is a plain `div`, not a `<dialog>`, so it has no Esc handler, no focus trap, and no keyboard path in or out. Treat as a defect to fix, not a pattern to copy.
+- **Focus:** whatever Nextra provides. This repo adds no `:focus-visible` rule of its own — if a component introduces a custom control, it owns giving it a visible focus ring.
 
 ## 6. Motion
 
-Calm and intentional, matching "calm, precise, trustworthy":
+Calm and intentional, matching "calm, precise, trustworthy". Docs motion is functional only — state feedback on controls, never storytelling.
 
-- Ease-out exponential curves only (`cubic-bezier(0.16, 1, 0.3, 1)`); no bounce, no elastic.
-- Content is visible by default; `.reveal` / `.animate-fade-in` are short fade-and-rise enhancements, never gates on visibility.
-- Signature moments — the live investigation, the NestForge DAG, the install terminal — may be alive, but as a bounded sequence, not an indefinite pulse.
-- The global `prefers-reduced-motion: reduce` block flattens all animations and transitions. Any JS-driven motion must check the same query itself; the CSS block can't reach it.
+- Transitions are short and property-scoped. The repo's habit is `all 0.2s` / `all 0.15s`; prefer naming the property (`border-color 0.2s`, `background 0.2s`) so a transition never animates layout by accident.
+- There is no shared easing token here. Browser default easing over these durations is fine; don't import the marketing site's exponential curve for a 150ms hover.
+- Content is visible by default. The only two keyframes in the repo (`pulse`, `fadeUp` in `HowTo.module.css`) are decoration on already-rendered content — motion must never gate visibility on a page someone is reading mid-install.
+- **Known gap: there is no `prefers-reduced-motion` rule anywhere in this repo.** PRODUCT.md commits to a reduced-motion path for every animation, and the two keyframes above currently have none. Any new motion must ship with the query, and the existing two need it retrofitted.
 
 ## 7. Do's and Don'ts
 
 ### Do:
-- **Do** let real product surfaces and real-shaped data make the claims — evidence over adjectives.
-- **Do** keep accent rare so the primary CTA is unmistakably *the* action on the page.
-- **Do** use JetBrains Mono to render telemetry as telemetry — it is the site's texture.
-- **Do** reach for the semantic tokens (`bg-surface`, `border-border`, `text-muted-foreground`) before writing a literal color.
+- **Do** let the working command, manifest, or diagram carry the page — evidence over adjectives, same as the marketing site, but here the evidence is the reader's own YAML.
+- **Do** keep accent rare. On a docs page it marks links, the active nav item, and the `<h2>` rule — nothing else competes with the code blocks.
+- **Do** use JetBrains Mono for machine data only (`--font-mono`, set on `code, pre, kbd, samp`). It is the site's texture.
+- **Do** reach for `var(--cardinal-accent)` and its siblings before writing a literal color, and let `nextra-theme-docs` own canvas, text, border, and code-block color.
+- **Do** pair every new literal color with a `.dark` override in the same module. `components/counters.module.css` is the counter-example — one hardcoded color, no dark rule.
 
 ### Don't:
 - **Don't** use gradient text, sparkle iconography, or "revolutionize" energy — the calm is the differentiation.
-- **Don't** ship hero-metric cards, identical icon card grids, or uppercase tracked eyebrows on every section.
+- **Don't** ship marketing furniture on a reference page: hero bands, CTA cards, icon grids, or uppercase tracked eyebrows on every section.
 - **Don't** use warm neutrals, pure #000, or neon-on-black.
-- **Don't** use side-stripe borders, nested cards, or content shadows heavier than `shadow-seat`.
-- **Don't** introduce a light-mode section; there is one canvas.
-- **Don't** reintroduce the retired light-theme tokens (`cobalt`, `ink`, `canvas`, `line`, `slate-*`, `ok`/`warn`/`bad`, `chart-1..5`). They were deleted from `tailwind.config.js` once the last consumer went; a literal color is a signal you want a semantic token that doesn't exist yet.
+- **Don't** assume a dark canvas. There is no single base here; both themes ship, and a color that only works in one is a defect.
+- **Don't** invent a new gray. The repo already carries 113 distinct literal colors across 10 CSS modules against 6 shared tokens — that drift is the known debt, not a pattern to extend.
+- **Don't** nest cards, or reach past a subtle resting shadow for content.
+
+**The one sanctioned side-stripe.** The marketing system forbids side-stripe borders. This repo makes exactly one exception: the 3px accent rule on `article h2` in `styles/globals.css`, which is the docs' main brand gesture. It is a global rule on one element — do not spread the pattern to cards, callouts, or panels.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,75 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Two confirmed primary readers, both practitioners, both arriving mid-task:
+
+1. **Self-hosting platform engineer** — an SRE or platform engineer standing up Cardinal Data Lake in their own cloud. They are in a terminal with a half-finished helm values file, an S3 bucket, and an OpenTelemetry collector. They need commands that work, values that are correct for their deployment model, and sizing they can defend.
+2. **Existing Cardinal UI customer** — already onboarded, now configuring the platform: integrations (GitHub, Jira, PagerDuty, Slack, Snowflake, BigQuery, ClickHouse, Postgres, Athena, Kubernetes, ServiceNow, Confluence, Teams), MCP clients, OIDC, Bedrock/Vertex model access, and agent-outcomes plugins for Claude Code / Codex / Cursor.
+
+Both are fluent in telemetry and skeptical of prose that does not resolve to a command, a field, or a diagram. The docs site is not a funnel; the reader has already chosen Cardinal.
+
+## Product Purpose
+
+`docs.cardinalhq.io` is the operating manual for Cardinal's two products. It exists so a reader can install, configure, and operate Cardinal without contacting support.
+
+**Success is an unblocked install, unaided** — the reader completes a real install or configuration end to end, in one sitting, without opening a support ticket. Fast reference lookup (a flag, a query-language clause, an integration field) is the recurring secondary job, but task completion is what the site is optimized for.
+
+## Positioning
+
+The docs are the honest counterpart to the marketing site. Where `cardinalhq.io` argues, `docs.cardinalhq.io` shows the exact YAML. Cardinal is self-hostable in the customer's own cloud, which means the documentation must be complete enough to operate the system without Cardinal's staff in the room — a claim most observability vendors' docs cannot make, because their product runs on the vendor's infrastructure.
+
+## Operating Context
+
+- Read on a laptop, usually beside a terminal and a cloud console; copy-paste out of the page is the dominant interaction.
+- Content is organized by product, matching the reader's mental model:
+  - `content/ui/` → `/ui/*` — Cardinal UI (formerly Maestro): install, integrations, MCP clients, agent outcomes, updates.
+  - `content/data-lake/` → `/data-lake/*` — Cardinal Data Lake (formerly Lakerunner): quickstart, install, manual install, collectors, CLI, architecture, instrumentation (Go/Java/Node/Python/React), query language, sizing, Loki comparison, OTel demo.
+  - `content/how-to/` → `/how-to/*` — cross-cutting recipes (OpenShift pod logs, Prometheus federation, Postgres exporter sidecar, Proxmox/Ceph OTel).
+- Several pages are interactive tools, not prose: `LakerunnerHelmValuesWizard`, `CollectorManifestsWizard`, `SizingEstimator`, `QuerySizingEstimator`, `QuickStartSteps`. These are the load-bearing parts of the install path and must keep working.
+- `SupportCallout` is the standard escape hatch when the docs run out; it appears across pages.
+
+## Capabilities and Constraints
+
+- **Stack:** Next.js 16 App Router + Nextra 4 (`nextra-theme-docs`), MDX content, TypeScript, pnpm. Navigation and page titles come from per-directory `_meta.ts`.
+- **Static-only, GitHub Pages.** `output: 'export'` builds to `out/`, deployed by `.github/workflows/nextjs.yml` to GitHub Pages at `docs.cardinalhq.io` (CNAME). **There is no server runtime** — no API routes, no middleware, no server-side redirects, no image optimization (`images.unoptimized`). Anything dynamic must be client-side.
+- **Search** is Pagefind, indexed at postbuild against the static `out/` directory.
+- **Legacy URLs must keep resolving.** `/maestro/*` → `/ui/*` and `/lakerunner/*` → `/data-lake/*`, implemented as an inline pre-hydration script in `app/not-found.tsx` because Pages offers no server redirect. Inbound links from before the rename must not break.
+- **Underlying product names are unchanged and binding.** The docs brand is Cardinal, but the CLI (`lakerunner`), helm charts, container image references, Kubernetes namespaces, and IAM identifiers keep their original names — they ship from separate repos. Never "fix" these to match the brand.
+- Fonts are Figtree (sans) and JetBrains Mono (mono), self-hosted via `next/font/google`, exposed as `--font-sans` / `--font-mono`.
+- Analytics is GA4 on the **same stream as `cardinalhq.io`** (`G-051X4VR1RL`), deliberately, so a visitor crossing between the sites stays one user/session.
+- `pnpm test` runs Jest, including a link checker (`lib/__tests__/links.test.ts`).
+
+## Brand Commitments
+
+- **Cardinal umbrella brand**, two products: **Cardinal UI** and **Cardinal Data Lake**. Former names (Maestro, Lakerunner) appear only where they still ship as identifiers.
+- The **chip mascot** (`/chip.png`) is the brand mark, used as navbar logo and favicon.
+- Voice inherited from the marketing site and product: calm, precise, trustworthy — a senior engineer explaining something real. Engineering candor over vendor enthusiasm.
+- The visual identity is the dark control-room system shared with `cardinalhq.io`; the incumbent record is this repo's `DESIGN.md`, copied from the website repo. **Open decision:** that document describes a dark-only marketing site, while this site runs the Nextra docs theme with a light/dark toggle. The reconciliation is a visual-world decision and has not been made.
+- Copyright: © 2025-2026 Cardinal HQ, Inc.
+
+## Evidence on Hand
+
+- Real product screenshots in `public/`, shown via `ExpandableImage` click-to-zoom.
+- Hand-built diagrams in `components/diagrams/`.
+- Working install artifacts: helm values, collector manifests, CLI invocations, instrumentation snippets per language — all generated or transcribed from the shipping products.
+- Comparative content: `data-lake/loki-comparison.mdx`.
+- **Absent, and not to be invented here:** pricing, benchmarks, customer names, testimonials, uptime or performance claims. Those live on the marketing site where they can be sourced. Docs state only what ships.
+
+## Product Principles
+
+1. **The reader is mid-install.** Every page assumes an interrupted task. Get them to a working command fast; explain after, or in a linked page.
+2. **Copy-paste must be correct.** A command, manifest, or values block that does not run as printed is a defect, not a typo. Interactive generators exist because hand-transcribed YAML drifts.
+3. **Only what ships.** No aspirational features, no invented numbers, no marketing claims. If it is not in the product, it is not in the docs.
+4. **Brand on the surface, original names underneath.** Cardinal is what the reader sees; `lakerunner` is what they type. Never collapse the two.
+5. **Nothing may break an inbound link.** URLs are the docs' public API — renames carry redirects forever.
+
+## Accessibility & Inclusion
+
+Inherits the marketing site's WCAG 2.1 AA commitment: body contrast ≥4.5:1, large text ≥3:1, full keyboard navigation, a visible focus ring on every interactive element, and a `prefers-reduced-motion` path for any animation. Docs-specific weight: the interactive wizards and estimators are form UI and must be keyboard-operable and screen-reader-labeled, not just visually correct.

--- a/content/data-lake/index.mdx
+++ b/content/data-lake/index.mdx
@@ -6,11 +6,11 @@ import LakerunnerOverviewDiagram from '../../components/diagrams/LakerunnerOverv
 
 <Image src="/lakerunner_left.png" alt="Cardinal Data Lake" width={200} height={200} />
 
-[Cardinal Data Lake](https://github.com/cardinalhq/lakerunner) transforms an S3-compatible bucket into a **production-grade Observability stack** in minutes.
+Cardinal Data Lake transforms an S3-compatible bucket into a **production-grade Observability stack** in minutes.
 
 ## What is Cardinal Data Lake?
 
-Cardinal Data Lake is an open-source observability data lake that stores logs, metrics, and traces in cloud object storage (S3, GCS, Azure Blob). It provides:
+Cardinal Data Lake is an observability data lake that stores logs, metrics, and traces in cloud object storage (S3, GCS, Azure Blob). It provides:
 
 - **Cost-effective storage** - Store petabytes of observability data at object storage prices
 - **Fast queries** - Columnar format with intelligent indexing for sub-second queries

--- a/content/data-lake/loki-comparison.mdx
+++ b/content/data-lake/loki-comparison.mdx
@@ -2,7 +2,7 @@
 
 ### Storage Costs
 
-| Dimension | Loki | Cardinal Cardinal Data Lake |
+| Dimension | Loki | Cardinal Data Lake |
 | - | - | - |
 | Primary storage | High cost SSD for speed | Low-cost Object storage (S3, Google Cloud Storage, etc) |
 | Storage format | Proprietary | Open: Apache Parquet |
@@ -13,7 +13,7 @@
 long-term value. Storing months or years of logs for analysis quickly becomes
 expensive.
 
-Cardinal Cardinal Data Lake stores data in analytics-optimized formats, allowing
+Cardinal Data Lake stores data in analytics-optimized formats, allowing
 multi-year retention at a fraction of the cost—often orders of magnitude
 cheaper than traditional log systems.
 
@@ -27,21 +27,21 @@ Loki relies heavily on label indexes:
 * Teams are often forced to limit labels, which limits insight
 * Accidents where high-cardinality labels are added can quickly increase cost
 
-Cardinal Cardinal Data Lake takes a different approach:
+Cardinal Data Lake takes a different approach:
 
-* Cardinal Cardinal Data Lake loves cardinality
+* Cardinal Data Lake loves cardinality
 * Minimal ingest-time indexing
 * Only a lightweight overview index is maintained outside of object storage
 * Full detail lives in S3-compatible storage and is accessed only when needed
 
-**Result:** Cardinal Cardinal Data Lake dramatically reduces the amount of expensive
+**Result:** Cardinal Data Lake dramatically reduces the amount of expensive
 non-S3 infrastructure while still enabling rich, flexible queries later.
 
 ---
 
 ### Compute Costs
 
-| Aspect | Loki | Cardinal Cardinal Data Lake |
+| Aspect | Loki | Cardinal Data Lake |
 | - | - | - |
 | Compute Model | Reserved or On-Demand | Spot or Preemptable |
 | Storage Model | SSD recommended for query speed | Object Storage with minimal SQL index |
@@ -53,7 +53,7 @@ With Loki, every query competes with ingestion and indexing. As usage grows
 across teams, this leads to over-provisioning, query throttling, and rising
 infrastructure spend.
 
-Cardinal Cardinal Data Lake decouples ingestion from analysis: data is processed once,
+Cardinal Data Lake decouples ingestion from analysis: data is processed once,
 queries spin up compute only when needed, and the system does not need to be
 sized for peak analytical demand 24/7.
 
@@ -68,7 +68,7 @@ sized for peak analytical demand 24/7.
 * Continuous tuning as usage grows
 * Debugging the debugger becomes a cost center
 
-#### Cardinal Cardinal Data Lake
+#### Cardinal Data Lake
 
 * Ingest once, analyze many times
 * Fewer hot paths
@@ -89,9 +89,9 @@ Teams often begin with Loki when:
 
 ---
 
-## Cardinal Cardinal Data Lake Wins on TCO
+## Cardinal Data Lake Wins on TCO
 
-Cardinal Cardinal Data Lake delivers lower total cost when:
+Cardinal Data Lake delivers lower total cost when:
 
 * Logs are used beyond incident response
 * You want observability to inform business and operational decisions

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -2,9 +2,7 @@ import SupportCallout from '../components/SupportCallout';
 
 # Cardinal Documentation
 
-Hello, and welcome! 👋
-
- New to Cardinal? We've got you covered, with a simple Quick Start to get you going:
+New to Cardinal? We've got you covered, with a simple Quick Start to get you going:
 
 ## Our Products
 - [Cardinal UI](/ui) - AI-powered observability and incident management platform.


### PR DESCRIPTION
## Content fixes

- **`content/index.mdx`** — removed "Hello, and welcome! 👋" (plus a stray leading space on the next line).
- **`content/data-lake/index.mdx`** — unlinked `github.com/cardinalhq/lakerunner` and dropped "open-source" from the product description. That repo is now **private**; verified both authenticated (`gh api` → `private`) and anonymously (`curl` → 404), so the link was dead for every logged-out reader.
- **`content/data-lake/loki-comparison.mdx`** — fixed 10 occurrences of "Cardinal **Cardinal** Data Lake", a leftover from the Lakerunner rename. Two were in customer-facing comparison-table headers.

### Links deliberately left alone

Every other `cardinalhq` repo referenced in the docs is still public (anonymous HTTP 200): `lakerunner-cli`, `charts`, `cardinal-claude-plugin`, `cardinal-codex-plugin`, `cardinal-cursor-plugin`, `cardinal-agent-plugins`, `oteltools`. That includes the `git clone` and the two `raw.githubusercontent.com` install pipelines in `content/data-lake/cli/claude-skill.mdx`, which all still resolve.

Also left as-is because they're true and unrelated to Cardinal's license: "Open: Apache Parquet" in the Loki table (file format, not license), the "open-source OpenTelemetry SDKs" reference, and the `gpt-oss` / "open models" Vertex model names.

## Impeccable artifacts

- **`PRODUCT.md`** — durable product truth captured via `/impeccable init`: the two confirmed readers (self-hosting platform engineer mid-install; existing Cardinal UI customer configuring integrations), success defined as *unblocked install, unaided*, and the hard constraints — GitHub Pages static-only (no server runtime, hence the pre-hydration redirect in `app/not-found.tsx`), `lakerunner`-family identifiers staying put under the Cardinal brand, Pagefind search, the shared GA4 stream, and "only what ships" as a content rule.
- **`.impeccable/critique/`** — first critique snapshot of the docs home + shell, scored **26/40** (Acceptable). Three P1s recorded as backlog: the home page routes nobody, the sidebar renders 130 items, and there is no docs design system (113 literal colors across 10 CSS modules against 6 shared tokens).
- **`DESIGN.md`** — inherited from the marketing site and renamed for this repo (`name: Cardinal Docs`).

## Known follow-up on DESIGN.md

The naming now matches, but the body still describes the marketing site rather than this one. Still inaccurate for `cardinal-docs`:

- Points at `src/index.css` and `tailwind.config.js` as source of truth — neither exists here; the real tokens are the six `--cardinal-*` vars in `styles/globals.css`.
- Asserts dark-only ("there is no light theme") — this site ships the Nextra docs theme with a light/dark toggle.
- Overview describes "the marketing site" and its persuade-mode goals.
- The retired-token don't-list refers to `tailwind.config.js` deletions that never happened in this repo.

Because the token set doesn't match what's shipped, the detector currently reports 379 findings against this repo that are noise as stated. `/impeccable document` would derive the real system from the shipped Nextra theme and make future scans meaningful.