### PR TITLE
deps: bump brace-expansion override to >=5.0.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core': '>=7.29.6'
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion: '>=5.0.8 <6'
+  brace-expansion: '>=5.0.9 <6'
   dompurify: '>=3.4.12'
   lodash-es: '>=4.18.0'
   mermaid: '>=11.15.0'
@@ -1506,8 +1506,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -5174,7 +5174,7 @@ snapshots:
       mathjax-full: 3.2.2
       react: 19.2.7
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7008,15 +7008,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 overrides:
   '@babel/core': '>=7.29.6'
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion: '>=5.0.8 <6'
+  brace-expansion: '>=5.0.9 <6'
   dompurify: '>=3.4.12'
   lodash-es: '>=4.18.0'
   mermaid: '>=11.15.0'


### PR DESCRIPTION
Fixes Dependabot alert #116 (high, brace-expansion ReDoS). Bumps the pnpm override so the lockfile resolves 5.0.9. Tests pass.