### PR TITLE
docs: drop refs to the removed ontology and orchestra planner

### DIFF
--- a/content/ui/install/environment.mdx
+++ b/content/ui/install/environment.mdx
@@ -82,13 +82,6 @@ Used by the Cardinal Data Lake provisioner when auto-configuring a new org's buc
 | `DEFAULT_BUCKET_REGION` | |
 | `DEFAULT_BUCKET_COLLECTOR_NAME` | |
 
-### Ontology / repos
-
-| Variable | Default | Notes |
-| -------- | ------- | ----- |
-| `ONTOLOGY_WORKSPACE_DIR` | `/tmp/ontology-workspaces` | Writable path for cloned repos. The default sits on the `tmp` emptyDir — fine for most installs |
-| `GITHUB_PAT` | — | Used by the ontology CLI, not at runtime |
-
 ### Observability
 
 | Variable | Default | Notes |

--- a/content/ui/install/helm-chart.mdx
+++ b/content/ui/install/helm-chart.mdx
@@ -47,7 +47,7 @@ maestro:
 | `maestro.env` | `[]` | **This is where you put OIDC, LLM, and `MAESTRO_BASE_URL` vars.** See [Environment variables](/ui/install/environment) |
 | `maestro.extraVolumes` / `extraVolumeMounts` | `[]` | Mount extra config or certs into the pod |
 
-The Cardinal UI pod runs with `readOnlyRootFilesystem: true`. A `tmp` emptyDir is mounted at `/tmp`. If you need additional writable paths (e.g., ontology workspaces), add them via `extraVolumes` + `extraVolumeMounts`.
+The Cardinal UI pod runs with `readOnlyRootFilesystem: true`. A `tmp` emptyDir is mounted at `/tmp`. If you need additional writable paths, add them via `extraVolumes` + `extraVolumeMounts`.
 
 An `initContainer` waits for the MCP gateway service to accept connections before Cardinal UI starts.
 

--- a/content/ui/install/vertex.mdx
+++ b/content/ui/install/vertex.mdx
@@ -212,7 +212,7 @@ Common failures:
 | `Vertex generateContent failed (404)` | Wrong model ID or the model isn't published in that region |
 | `Vertex auth client returned no access token` | Workload Identity binding is missing or the KSA name doesn't match — check the `iam.gke.io/gcp-service-account` annotation |
 | `serviceAccountJson missing client_email` | The pasted JSON isn't a service-account key (e.g. it's an OAuth client JSON) |
-| `unknown_tool` warnings in logs after a tool call | A tool-call ID round-trip recovery happened; usually benign, but if the same tool keeps showing it, check that the orchestra executor isn't synthesizing its own IDs |
+| `unknown_tool` warnings in logs after a tool call | A tool-call ID round-trip recovery happened; usually benign, but if the same tool keeps showing it, check that the caller isn't synthesizing its own tool-call IDs |
 
 The model catalog **deliberately excludes** Gemini 2.5 Pro and Gemini 3 from the `google-vertex` provider in this release. Hand-editing a catalog row to use one will fail fast at resolve time with `"Vertex model ... requires raw thoughtSignature round-tripping"` — this is intentional, not a bug.
 

--- a/content/ui/integrations/github.mdx
+++ b/content/ui/integrations/github.mdx
@@ -68,7 +68,7 @@ https://<your-maestro-base-url>/api/github-app/setup
 | **Pull requests** | Read & write | List/read PRs and changed files; open PRs (write actions are human-approved) |
 | **Issues** | Read & write | List/create/update issues, comment on issues and PRs (human-approved) |
 | **Deployments** | Read | Deployment timeline in the outcomes dashboard |
-| **Commit statuses** | Read | CI status signal during investigations |
+| **Commit statuses** | Read | CI status signal |
 
 > Comments on pull requests go through the Issues permission (GitHub models PR comments as issue comments), so no separate "PR comment" permission exists.
 

--- a/content/ui/integrations/kubernetes.mdx
+++ b/content/ui/integrations/kubernetes.mdx
@@ -2,14 +2,14 @@ import SupportCallout from '../../../components/SupportCallout';
 
 # Kubernetes
 
-Connect Cardinal to a Kubernetes cluster so the AI agent can investigate cluster state and so chart markers in **Explore** highlight when Kubernetes events (BackOff, FailedScheduling, Unhealthy, etc.) coincide with metric or log changes.
+Connect Cardinal to a Kubernetes cluster so your connected agent can read cluster state and so chart markers in **Explore** highlight when Kubernetes events (BackOff, FailedScheduling, Unhealthy, etc.) coincide with metric or log changes.
 
 ## Overview
 
 The Kubernetes integration is **read-only**. It surfaces two capabilities:
 
 - **Chart markers** — `core/v1/Event` records appear as colored markers on the Metrics and Logs timelines, alongside any GitHub events you have enabled. Useful for correlating "what broke" with "what changed."
-- **Agent tools** — read-only kubectl-equivalent access for the AI agent: `list_events`, `list_resources`, `get_resource`, `get_logs`, `list_api_resources`.
+- **MCP tools** — read-only kubectl-equivalent access over the MCP endpoint: `list_events`, `list_resources`, `get_resource`, `get_logs`, `list_api_resources`.
 
 Cardinal never writes to your cluster. The integration stores your credentials encrypted at rest and transmits them per-request to the agent gateway.
 


### PR DESCRIPTION
Companion to cardinalhq/conductor#1549, which removes the last interactive LLM surfaces.

Mechanical only — everything here documents something that no longer exists in code:

- `install/environment.mdx` — deletes the whole **Ontology / repos** env table (`ONTOLOGY_WORKSPACE_DIR`, `GITHUB_PAT`). Neither string appears anywhere in conductor anymore.
- `install/helm-chart.mdx` — drops "(e.g., ontology workspaces)" as the example for extra writable paths.
- `install/vertex.mdx` — a troubleshooting row pointed at the `orchestra executor`; repointed at the caller generically.
- `integrations/kubernetes.mdx` — "so the AI agent can investigate cluster state" → reads cluster state; "**Agent tools**" → "**MCP tools**", since these are reached over the MCP endpoint by the user's own agent.
- `integrations/github.mdx` — "CI status signal during investigations" → "CI status signal".

## Not done here — needs a product-voice call

`content/ui/index.mdx` still opens *"Cardinal UI is Cardinal's AI agent for observability"* and its **How it works** section describes the Orchestra planning engine and \`plan → execute → evaluate\`. That engine is deleted. The phrase "the AI agent" also appears on 15 integration pages (athena, bigquery, clickhouse, confluence, github, index, jira, kubernetes, lakerunner, pagerduty, postgres, servicenow, slack, snowflake, teams).

Those integrations all still work — they're MCP tools served to external agents like the Claude Code plugin — so this is a repositioning rather than a deletion, and it's the product's voice to write. Left deliberately untouched.