### PR TITLE
docs: use deployment.environment.name in proxmox guides

### DIFF
--- a/content/how-to/proxmox-ceph-otel.mdx
+++ b/content/how-to/proxmox-ceph-otel.mdx
@@ -247,7 +247,7 @@ processors:
 
   resource/common:
     attributes:
-      - key: deployment.environment
+      - key: deployment.environment.name
         value: <your-environment>
         action: upsert
       - key: proxmox.cluster.name

--- a/content/how-to/proxmox-otlp-metric-server.mdx
+++ b/content/how-to/proxmox-otlp-metric-server.mdx
@@ -87,7 +87,7 @@ Other destinations use their own header — e.g. `{"Authorization": "Bearer <tok
 
 ```json copy
 {
-  "deployment.environment": "production",
+  "deployment.environment.name": "production",
   "proxmox.cluster.name": "my-cluster"
 }
 ```


### PR DESCRIPTION
Both Proxmox guides told users to set `deployment.environment`, but the customer intake reads `deployment.environment.name`:

```yaml
# customer-intake-config.yaml
- key: "k8s.cluster.name"
  action: insert
  from_attribute: "deployment.environment.name"
- key: "k8s.namespace.name"
  action: insert
  from_attribute: "deployment.environment.name"
```

So a user following either guide exactly got neither `k8s.cluster.name` nor `k8s.namespace.name` populated — while the doc claims these attributes are "how you tell clusters apart downstream."

Every other doc in this repo (all the instrumentation guides) already uses `deployment.environment.name`, which is also the current semconv spelling. These two proxmox guides were the outliers.