### PR TITLE
Add Explore help documentation

### DIFF
--- a/content/ui/_meta.ts
+++ b/content/ui/_meta.ts
@@ -5,6 +5,7 @@ export default {
   },
   install: 'Installation',
   integrations: 'Integrations',
+  explore: 'Explore',
   'mcp-clients': 'Connect AI Clients',
   updates: 'Software Updates',
   'agent-outcomes': 'Agent Outcomes',

--- a/content/ui/explore/_meta.ts
+++ b/content/ui/explore/_meta.ts
@@ -1,0 +1,6 @@
+export default {
+  index: 'Overview',
+  logs: 'Logs',
+  metrics: 'Metrics',
+  traces: 'Traces',
+}

--- a/content/ui/explore/index.mdx
+++ b/content/ui/explore/index.mdx
@@ -1,0 +1,52 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Explore
+
+Explore is the place to query and investigate the logs, metrics, and traces stored in Cardinal Data Lake. Each view is tuned for its signal, but they share the same data source and time controls so you can move between them without rebuilding the investigation from scratch.
+
+Open **Explore** in Cardinal UI, then choose **Logs**, **Metrics**, or **Traces**.
+
+## Choose a data source
+
+The instance selector beside the page title chooses the Cardinal Data Lake deployment to query. If your organization has one available instance, Cardinal selects it automatically. With more than one, check the instance before comparing results across pages.
+
+If no instance is available, connect a [Cardinal Data Lake integration](/ui/integrations/lakerunner) or ask an organization owner to make one available to Explore.
+
+## Time range and refresh
+
+Use the time picker in the upper-right corner to choose a relative range, such as the last hour, or enter an exact start and end time. The arrow controls move the current window backward or forward by one full window, which is useful when comparing a change with the period immediately before it.
+
+**Refresh** runs the current view again. After the first result loads, the refresh menu can also run it on an interval. Automatic refresh pauses while a query is being edited or when the current page has nothing to refresh.
+
+Start with a narrow range when a query covers high-volume data. Widen it once the service, label, or operation you need is isolated.
+
+## Move between signals
+
+Explore carries useful context between signal views:
+
+- A metric series can open related **Logs** using the series labels as filters.
+- A metric series with a service label can open that service in **Traces**.
+- A filtered log view can place matching log events on metric charts.
+- A selected trace opens its related logs in the trace drawer when trace IDs are present on both signals.
+
+These links preserve the active time range. Review the generated filters after moving between views; a label that identifies a metric series may be named differently on log records or spans.
+
+## Sharing a view
+
+Logs and Metrics include a **Share** button. It copies a link containing the current query, filters, time range, and other relevant view state. Large views may use a short saved-view URL instead of putting the full state in the address.
+
+Trace ID searches are reflected in the Traces URL, so those searches can be bookmarked or copied from the browser. The recipient still needs access to the same Cardinal organization and data source.
+
+## When a view has no data
+
+Check these items before changing the query:
+
+1. Confirm the selected Cardinal Data Lake instance.
+2. Widen the time range.
+3. Clear filters one at a time.
+4. Confirm that the service is sending the expected signal. See [App Instrumentation](/data-lake/instrumentation).
+5. For service graphs, confirm that the collector gateway is producing span-derived metrics. See [OpenTelemetry Collectors](/data-lake/collectors#gateway).
+
+Continue with [Logs](/ui/explore/logs), [Metrics](/ui/explore/metrics), or [Traces](/ui/explore/traces).
+
+<SupportCallout />

--- a/content/ui/explore/logs.mdx
+++ b/content/ui/explore/logs.mdx
@@ -1,0 +1,76 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Explore Logs
+
+Explore Logs combines a log search with a service-level distribution, severity totals, and the matching log lines. Use the Builder for a quick search or switch to Code when you already have a LogQL expression.
+
+## Build a log search
+
+The **Builder** narrows logs with four kinds of input:
+
+- **Service name** selects one or more services.
+- **Level** selects the severity values present in the current result.
+- **Message contains** matches text in the log message.
+- **Field filters** match indexed log attributes. Each row supports equality, inequality, and regular-expression operators where the field allows them.
+
+Available fields and values are scoped by the other filters and the selected time range. If a value you expect is missing, widen the range or remove a neighboring filter before entering it manually.
+
+The page updates as the Builder changes. Click a service or severity in the distribution chart to apply the same filter without returning to the left panel.
+
+## Write LogQL
+
+Switch to **Code** to edit the LogQL expression directly. A raw log selector continues to drive the distribution, KPI, and log-line views. An aggregation expression produces a time-series chart instead.
+
+For example:
+
+```logql
+{resource_service_name="checkout"} |~ "(?i)timeout|exception"
+```
+
+Explore checks the expression while you type. Expressions that cannot be represented by the Builder stay in Code mode. Cardinal Data Lake implements a focused LogQL subset; see [Log Queries](/data-lake/query-language#log-queries-logql-style) and [Supported Subset](/data-lake/query-language#supported-subset) for the available syntax.
+
+## Investigate log volume
+
+The distribution chart groups matching logs by service and severity. Use it to find which service contributes most of the current volume and whether that volume is mostly informational, warnings, or errors.
+
+- Click a **service row** to open its severity history over time.
+- Click a **severity segment** to add that level to the search.
+- Use **All services** to return from a service drill-down.
+- Use the KPI chips to compare total volume and severity counts for the current scope.
+
+When event sources are active, the volume timeline also shows markers for events that occurred in the selected window.
+
+## Error fingerprints
+
+Select the **Errors** or **Warnings** KPI when analysis tools are available to group similar messages into fingerprints. The overview highlights recurring patterns instead of making you inspect each line separately.
+
+Select a fingerprint to chart its frequency over the last 15 days. This is useful for distinguishing a new failure from a noisy, long-running one. The fingerprint is an analysis aid; the original matching log lines remain the source of detail.
+
+## Inspect and export log lines
+
+Expand a log line to see all of its attributes. From an attribute you can:
+
+- add it to the current filter,
+- group matching lines by its values when analysis tools are available, or
+- add the field as a visible table column.
+
+Use **Columns** above the result to keep useful fields visible across the current table. Change the sort control to read newest-first or oldest-first, and continue loading results when the first page does not cover the full range.
+
+**Download CSV** exports the matching rows with the visible fields. A broad time range can produce a large export, so apply the service and field filters you need first.
+
+## Events and correlation
+
+Choose **Events** to add operational events to the timeline. Available sources depend on your organization’s integrations:
+
+- [Kubernetes events](/ui/integrations/kubernetes#using-explore-correlation) show scheduling failures, restarts, health failures, and other cluster changes.
+- A connected [GitHub integration](/ui/integrations/github) can provide deployments, pull requests, and releases.
+
+Use **Correlate to Metrics** after applying log filters to open Metrics with those matching log events as markers. Selecting a marker there opens the nearby log lines, making it easier to compare a spike with the messages emitted at the same time.
+
+## Share and reuse
+
+**Share** copies the current filters, LogQL expression, sort order, and time range into a link. Use **Add to Dashboard** on a distribution, service drill-down, aggregation, or log result to reuse that query in a dashboard panel.
+
+Dashboard panels keep the query rather than a snapshot of the current result. Give the panel a name that describes the service and condition so it remains understandable after the incident ends.
+
+<SupportCallout />

--- a/content/ui/explore/metrics.mdx
+++ b/content/ui/explore/metrics.mdx
@@ -1,0 +1,78 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Explore Metrics
+
+Explore Metrics builds and compares PromQL time series. A view can contain several queries and formulas, which makes it useful for checking related signals or calculating ratios without first creating a dashboard.
+
+## Build a metric query
+
+In **Builder** mode, choose a metric and then refine it with:
+
+- **Labels** to filter the series. Equality, inequality, and regular-expression operators are available.
+- **Aggregation** to combine matching series with functions such as sum, average, minimum, maximum, count, or percentile.
+- **Value As** to use raw values, rates, or changes where the metric type supports them.
+- **Group By** to keep separate lines for selected labels.
+
+The builder identifies common counter and gauge types and chooses a useful starting calculation. Review that calculation before using the result for an alert or SLO.
+
+Switch to **Code** to enter PromQL directly. Code-mode queries run when you select **Run Query**, which lets you finish editing a larger expression before sending it. See [Metric Queries](/data-lake/query-language#metric-queries-promql-style) and [Supported Subset](/data-lake/query-language#supported-subset) for supported syntax.
+
+## Discover metrics by tag
+
+Choose **Discover metrics by tag** when you know the workload label but not the metric names. Build a scope such as `service_name = checkout`, select the metrics you want, and paint them into the page as query panels.
+
+The scope bar stays above the generated panels:
+
+- Editing a scope filter updates every linked panel.
+- **Group by** applies labels shared by all linked metrics.
+- A panel detaches when its query is edited independently.
+- **Detach all** keeps the current filters on each panel and stops later scope changes from updating them.
+
+This workflow is especially useful for comparing several runtime or infrastructure metrics for the same service, namespace, pod, or cluster.
+
+## Queries and formulas
+
+Use **Add Query** to place another metric beside the current one. Queries are assigned letters in page order. Collapse the query list when you want more room for charts, or clear all query panels while keeping any formulas you still need.
+
+Use **Add Formula** to calculate from those query letters. For example:
+
+```text
+(A / B) * 100
+```
+
+Formulas recompute when their source queries update. A formula can reference query panels, but it cannot reference another formula. If a query is removed, update or remove formulas that refer to its letter.
+
+## Analyze chart series
+
+Each query and formula renders as a time-series chart. The legend identifies the labels that distinguish one series from another. Depending on the labels and connected integrations, a legend row can offer these drill actions:
+
+- **Open in Logs** carries the series labels into a filtered Logs view.
+- **Open in Spans** opens the matching service in Traces.
+- **Open Infra Map** opens the related Kubernetes workload and its neighborhood.
+
+An action appears only when the series contains enough information to build the destination. For example, **Open in Spans** needs a service label and **Open Infra Map** needs recognizable Kubernetes labels plus a connected cluster.
+
+## Anomalies and outliers
+
+Use **Detect anomalies** to check the current series for unusually high spikes and low drops. Cardinal evaluates both directions and shows the periods that differ from the expected shape.
+
+Use **Find outliers** when a query returns a cohort of comparable series, such as pods or hosts. It identifies members whose behavior differs from their peers. Outlier detection is available for query panels but not formulas because the cohort labels must be applied back to the original metric query.
+
+These checks are starting points for investigation. Confirm a flagged period against the chart, related logs, deployments, and known traffic changes before treating it as a fault.
+
+## Correlation
+
+Metrics can show two kinds of markers:
+
+- **Log correlation** comes from **Correlate to Metrics** in Explore Logs. Select a marker to inspect the nearby matching log lines.
+- **Events** come from connected sources such as Kubernetes or GitHub. Configure them with the **Events** button and select only the clusters, namespaces, repositories, or event types relevant to the chart.
+
+See [Using Explore correlation](/ui/integrations/kubernetes#using-explore-correlation) for Kubernetes setup. When a series contains Kubernetes resource labels, its legend may also open the Infra Map for a live view of the related workload.
+
+## Share and reuse
+
+**Share** copies all active queries, formulas, scope links, and the time range into a link. **Reset** clears the page and returns it to an empty query.
+
+Use **Add to dashboard** on a query or formula chart to create a reusable panel. Formula panels preserve the formula along with the resolved PromQL, so they can still be edited as formulas in the dashboard.
+
+<SupportCallout />

--- a/content/ui/explore/traces.mdx
+++ b/content/ui/explore/traces.mdx
@@ -1,0 +1,59 @@
+import SupportCallout from '../../../components/SupportCallout';
+
+# Explore Traces
+
+Explore Traces shows how requests move between services, which operations are slow or failing, and the spans and logs that make up an individual trace.
+
+## Find traces and spans
+
+Start from the service overview or select a service in the left panel. The span filters narrow the result:
+
+- **Trace ID** finds the services and spans touched by one trace. The active Trace ID is kept in the URL for bookmarking and sharing.
+- **Status** switches between all spans and error spans when the service has recorded failures.
+- **Operation contains** matches part of a span name, such as `GET /checkout`.
+- **Min duration** removes spans faster than the entered duration in milliseconds.
+- **Flow** appears after selecting a connection in the service graph and limits spans to that client/server path.
+
+Span searches use the page time range. If a known Trace ID returns no result, widen the range before assuming that trace retention has expired.
+
+## Service overview
+
+Before a service is selected, the overview summarizes each service with request count, error count, error rate, and average latency. Select a row to open its service graph, operation cards, and recent spans.
+
+A service may appear in the overview even when it has no spans of its own. This happens when another instrumented service records it as a peer. Instrument that service to make its operations and spans available; see [App Instrumentation](/data-lake/instrumentation).
+
+## Service graph
+
+The service graph shows incoming and outgoing relationships for the selected service. Switch among:
+
+- **Requests** for call volume,
+- **Errors** for failed calls, and
+- **Latency** for average request duration.
+
+Select a service node to pivot the page to that service. Select a connection to filter the spans to that flow and open a chart of its request volume, errors, or latency over the current time range.
+
+Service graphs use metrics derived from spans by the collector gateway. A deployment that stores raw spans without generating service-graph metrics can return traces while leaving the graph empty. See the [collector gateway](/data-lake/collectors#gateway) configuration.
+
+## Operations and spans
+
+Operation cards summarize request count, error count, and average latency for each operation in the selected service. Select an operation to filter the span list; select it again or remove the chip to return to all operations.
+
+The span table shows the service, operation, start time, duration, and status. Change the page size when you need a broader sample and use **Load more** to continue backward through the selected range. Filters are applied by the query, so loading more keeps the same service, status, operation, duration, Trace ID, and flow constraints.
+
+Select a span to open its full trace.
+
+## Trace waterfall
+
+The trace drawer arranges spans on a shared timeline. Expand a span to inspect its IDs, parent, duration, status, and attributes. The relative position and width show when the span ran and how much of the total trace time it consumed.
+
+Use **Group by** beside an attribute to summarize that field across related spans. This can quickly reveal which namespace, pod, endpoint, database, or status value contributes most often without closing the trace.
+
+Parent/child timing helps locate where time accumulated, but it does not by itself prove the root cause. Compare a slow span with its attributes, neighboring spans, and correlated logs.
+
+## Correlated logs
+
+Open the **Logs** tab in the trace drawer to load log records carrying the selected Trace ID during the current time range. Expand a line for its attributes, filter on useful values, or group matching lines by a field when analysis tools are available.
+
+An empty Logs tab usually means the application is not adding trace context to its log records, the logs are outside the selected range, or the logs and traces were sent to different Cardinal Data Lake instances. Configure your logging instrumentation to include `trace_id` and `span_id` alongside each record.
+
+<SupportCallout />


### PR DESCRIPTION
## Summary
- add an Explore category to the UI documentation
- document common Explore behavior plus Logs, Metrics, and Traces workflows
- provide stable section anchors for contextual help links

## Verification
- pnpm test:links
- pnpm build
- verified every Conductor help target against generated documentation anchors
- visually reviewed the rendered Explore documentation navigation and Metrics page